### PR TITLE
temporarily force source path to basename

### DIFF
--- a/src/lib/driver/driver.mbt
+++ b/src/lib/driver/driver.mbt
@@ -500,7 +500,7 @@ pub fn compile(
     meta,
     output,
     source_map_builder?,
-    grammar_filename=filename,
+    grammar_filename=@_driver_util.path_basename(filename),
     mode=match mode {
       OnlyTokens => panic()
       Default => Default

--- a/src/lib/driver/util/util.mbt
+++ b/src/lib/driver/util/util.mbt
@@ -1,0 +1,15 @@
+///|
+pub fn path_basename(path : String) -> String {
+  let lastSlashIndex = path.last_index_of("/")
+  if lastSlashIndex == -1 {
+    // Fallback to windows path separator
+    let lastBackslashIndex = path.last_index_of("\\")
+    if lastBackslashIndex == -1 {
+      return path
+    } else {
+      return path.substring(start=lastBackslashIndex + 1)
+    }
+  } else {
+    path.substring(start=lastSlashIndex + 1)
+  }
+}


### PR DESCRIPTION
We wish to use relative path for `source` field in `.map.json`, but we don't have cross platform path package at the present. So we temporarily use basename instead.