### PR TITLE
feat: add elaborate phase

### DIFF
--- a/boot/moonyacc.js
+++ b/boot/moonyacc.js
@@ -88,10 +88,10 @@ function Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$Unrecognized(
   this._0 = param0;
 }
 Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$Unrecognized.prototype.$tag = 3;
-function Error$moonbitlang$47$x$47$fs$46$IOError$46$NotFound(param0) {
+function Error$moonbitlang$47$x$47$fs$46$IOError$46$IOError(param0) {
   this._0 = param0;
 }
-Error$moonbitlang$47$x$47$fs$46$IOError$46$NotFound.prototype.$tag = 1;
+Error$moonbitlang$47$x$47$fs$46$IOError$46$IOError.prototype.$tag = 1;
 function Error$moonbitlang$47$core$47$strconv$46$StrConvError$46$StrConvError(param0) {
   this._0 = param0;
 }
@@ -250,9 +250,10 @@ function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$JumpOuter$9$(param0
   this._0 = param0;
 }
 $64$moonbitlang$47$core$47$builtin$46$ForeachResult$JumpOuter$9$.prototype.$tag = 4;
-const moonbitlang$x$fs$internal$ffi$$read_file_to_string_internal = function(path) {   fs = require('fs');   let content = fs.readFileSync(path, 'utf8');   return content;  };
-const moonbitlang$x$fs$internal$ffi$$write_string_to_file_internal = function(path, content) {   fs = require('fs');   fs.writeFileSync(path, content, 'utf8');  };
-const moonbitlang$x$fs$internal$ffi$$path_exists_internal = function(path) {   fs = require('fs');   return fs.existsSync(path);  };
+const moonbitlang$x$fs$$read_file_ffi = function(path) {    var fs = require('fs');    try {      const content = fs.readFileSync(path);      globalThis.fileContent = content;      return 0;    } catch (error) {      globalThis.errorMessage = error.message;      return -1;    }  };
+const moonbitlang$x$fs$$write_file_ffi = function(path, content) {    var fs = require('fs');    try {      fs.writeFileSync(path, Buffer.from(content));      return 0;    } catch (error) {      globalThis.errorMessage = error.message;      return -1;    }  };
+const moonbitlang$x$fs$$get_file_content_ffi = function() {    return globalThis.fileContent;  };
+const moonbitlang$x$fs$$get_error_message_ffi = function() {    return globalThis.errorMessage || '';  };
 function Result$Err$10$(param0) {
   this._0 = param0;
 }
@@ -269,6 +270,38 @@ function Result$Ok$11$(param0) {
   this._0 = param0;
 }
 Result$Ok$11$.prototype.$tag = 1;
+function Result$Err$12$(param0) {
+  this._0 = param0;
+}
+Result$Err$12$.prototype.$tag = 0;
+function Result$Ok$12$(param0) {
+  this._0 = param0;
+}
+Result$Ok$12$.prototype.$tag = 1;
+function Result$Err$13$(param0) {
+  this._0 = param0;
+}
+Result$Err$13$.prototype.$tag = 0;
+function Result$Ok$13$(param0) {
+  this._0 = param0;
+}
+Result$Ok$13$.prototype.$tag = 1;
+function Result$Err$14$(param0) {
+  this._0 = param0;
+}
+Result$Err$14$.prototype.$tag = 0;
+function Result$Ok$14$(param0) {
+  this._0 = param0;
+}
+Result$Ok$14$.prototype.$tag = 1;
+function Result$Err$15$(param0) {
+  this._0 = param0;
+}
+Result$Err$15$.prototype.$tag = 0;
+function Result$Ok$15$(param0) {
+  this._0 = param0;
+}
+Result$Ok$15$.prototype.$tag = 1;
 const moonbitlang$x$sys$internal$ffi$$get_cli_args_internal = function() {   return process.argv;  };
 function $64$Yoorkin$47$ArgParser$46$Spec$Unit(param0) {
   this._0 = param0;
@@ -290,14 +323,14 @@ function $64$Yoorkin$47$ArgParser$46$Spec$Clear(param0) {
   this._0 = param0;
 }
 $64$Yoorkin$47$ArgParser$46$Spec$Clear.prototype.$tag = 4;
-function Result$Err$12$(param0) {
+function Result$Err$16$(param0) {
   this._0 = param0;
 }
-Result$Err$12$.prototype.$tag = 0;
-function Result$Ok$12$(param0) {
+Result$Err$16$.prototype.$tag = 0;
+function Result$Ok$16$(param0) {
   this._0 = param0;
 }
-Result$Ok$12$.prototype.$tag = 1;
+Result$Ok$16$.prototype.$tag = 1;
 function $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$Dollar(param0) {
   this._0 = param0;
 }
@@ -327,14 +360,14 @@ function $64$moonbitlang$47$yacc$47$lib$47$parser$46$ClauseItemIdent$Name(param0
   this._0 = param0;
 }
 $64$moonbitlang$47$yacc$47$lib$47$parser$46$ClauseItemIdent$Name.prototype.$tag = 1;
-function Result$Err$13$(param0) {
+function Result$Err$17$(param0) {
   this._0 = param0;
 }
-Result$Err$13$.prototype.$tag = 0;
-function Result$Ok$13$(param0) {
+Result$Err$17$.prototype.$tag = 0;
+function Result$Ok$17$(param0) {
   this._0 = param0;
 }
-Result$Ok$13$.prototype.$tag = 1;
+Result$Ok$17$.prototype.$tag = 1;
 const $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$EOF = { $tag: 0 };
 function $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$IDENT(param0) {
   this._0 = param0;
@@ -378,12 +411,12 @@ const $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$COLON = { $tag: 18 };
 const $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$BAR = { $tag: 19 };
 const $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$EQ = { $tag: 20 };
 const $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$SEMI = { $tag: 21 };
-const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$14$ = { $tag: 0 };
-function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$14$(param0, param1) {
+const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$18$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$18$(param0, param1) {
   this._0 = param0;
   this._1 = param1;
 }
-$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$14$.prototype.$tag = 1;
+$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$18$.prototype.$tag = 1;
 function $64$moonbitlang$47$yacc$47$lib$47$parser$46$Declaration$Start(param0) {
   this._0 = param0;
 }
@@ -425,24 +458,24 @@ function $64$moonbitlang$47$yacc$47$lib$47$parser$46$Declaration$Nonassoc(param0
   this._0 = param0;
 }
 $64$moonbitlang$47$yacc$47$lib$47$parser$46$Declaration$Nonassoc.prototype.$tag = 8;
-const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$15$ = { $tag: 0 };
-function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$15$(param0, param1) {
+const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$19$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$19$(param0, param1) {
   this._0 = param0;
   this._1 = param1;
 }
-$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$15$.prototype.$tag = 1;
-const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$16$ = { $tag: 0 };
-function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$16$(param0, param1) {
+$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$19$.prototype.$tag = 1;
+const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$20$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$20$(param0, param1) {
   this._0 = param0;
   this._1 = param1;
 }
-$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$16$.prototype.$tag = 1;
-const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$17$ = { $tag: 0 };
-function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$17$(param0, param1) {
+$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$20$.prototype.$tag = 1;
+const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$21$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$21$(param0, param1) {
   this._0 = param0;
   this._1 = param1;
 }
-$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$17$.prototype.$tag = 1;
+$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$21$.prototype.$tag = 1;
 function $64$moonbitlang$47$yacc$47$lib$47$parser$46$ClauseItemSymbol$Symbol(param0) {
   this._0 = param0;
 }
@@ -451,12 +484,12 @@ function $64$moonbitlang$47$yacc$47$lib$47$parser$46$ClauseItemSymbol$Image(para
   this._0 = param0;
 }
 $64$moonbitlang$47$yacc$47$lib$47$parser$46$ClauseItemSymbol$Image.prototype.$tag = 1;
-const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$18$ = { $tag: 0 };
-function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$18$(param0, param1) {
+const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$22$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$22$(param0, param1) {
   this._0 = param0;
   this._1 = param1;
 }
-$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$18$.prototype.$tag = 1;
+$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$22$.prototype.$tag = 1;
 const $64$moonbitlang$47$yacc$47$lib$47$parser$46$YYDecision$Accept = { $tag: 0 };
 function $64$moonbitlang$47$yacc$47$lib$47$parser$46$YYDecision$Shift(param0) {
   this._0 = param0;
@@ -475,22 +508,22 @@ function $64$moonbitlang$47$yacc$47$lib$47$parser$46$YYDecision$ReduceNoLookahea
 }
 $64$moonbitlang$47$yacc$47$lib$47$parser$46$YYDecision$ReduceNoLookahead.prototype.$tag = 3;
 const $64$moonbitlang$47$yacc$47$lib$47$parser$46$YYDecision$Error = { $tag: 4 };
-function Result$Err$19$(param0) {
+function Result$Err$23$(param0) {
   this._0 = param0;
 }
-Result$Err$19$.prototype.$tag = 0;
-function Result$Ok$19$(param0) {
+Result$Err$23$.prototype.$tag = 0;
+function Result$Ok$23$(param0) {
   this._0 = param0;
 }
-Result$Ok$19$.prototype.$tag = 1;
-function Result$Err$20$(param0) {
+Result$Ok$23$.prototype.$tag = 1;
+function Result$Err$24$(param0) {
   this._0 = param0;
 }
-Result$Err$20$.prototype.$tag = 0;
-function Result$Ok$20$(param0) {
+Result$Err$24$.prototype.$tag = 0;
+function Result$Ok$24$(param0) {
   this._0 = param0;
 }
-Result$Ok$20$.prototype.$tag = 1;
+Result$Ok$24$.prototype.$tag = 1;
 function $i32_ctz(a) {
   a >>>= 0;
   if (a === 0) return 32;
@@ -502,29 +535,29 @@ function $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Lookahead$Input(param0) {
   this._0 = param0;
 }
 $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Lookahead$Input.prototype.$tag = 1;
-const $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Continue$21$ = { $tag: 0 };
-function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Break$21$(param0) {
+const $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Continue$25$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Break$25$(param0) {
   this._0 = param0;
 }
-$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Break$21$.prototype.$tag = 1;
-function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Return$21$(param0) {
+$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Break$25$.prototype.$tag = 1;
+function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Return$25$(param0) {
   this._0 = param0;
 }
-$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Return$21$.prototype.$tag = 2;
-function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Error$21$(param0) {
+$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Return$25$.prototype.$tag = 2;
+function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Error$25$(param0) {
   this._0 = param0;
 }
-$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Error$21$.prototype.$tag = 3;
-function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$JumpOuter$21$(param0) {
+$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Error$25$.prototype.$tag = 3;
+function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$JumpOuter$25$(param0) {
   this._0 = param0;
 }
-$64$moonbitlang$47$core$47$builtin$46$ForeachResult$JumpOuter$21$.prototype.$tag = 4;
-const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$22$ = { $tag: 0 };
-function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$22$(param0, param1) {
+$64$moonbitlang$47$core$47$builtin$46$ForeachResult$JumpOuter$25$.prototype.$tag = 4;
+const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$26$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$26$(param0, param1) {
   this._0 = param0;
   this._1 = param1;
 }
-$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$22$.prototype.$tag = 1;
+$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$26$.prototype.$tag = 1;
 function $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Reduce_conflict_resolved_by_presentation_order(param0, param1, param2, param3) {
   this._0 = param0;
   this._1 = param1;
@@ -546,14 +579,14 @@ function $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Shift_red
   this._3 = param3;
 }
 $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Shift_reduce_conflict_not_resolved_because_of_non_assoc.prototype.$tag = 2;
-function Result$Err$23$(param0) {
+function Result$Err$27$(param0) {
   this._0 = param0;
 }
-Result$Err$23$.prototype.$tag = 0;
-function Result$Ok$23$(param0) {
+Result$Err$27$.prototype.$tag = 0;
+function Result$Ok$27$(param0) {
   this._0 = param0;
 }
-Result$Ok$23$.prototype.$tag = 1;
+Result$Ok$27$.prototype.$tag = 1;
 function $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(param0) {
   this._0 = param0;
 }
@@ -567,12 +600,12 @@ function $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Conflict(param0) {
   this._0 = param0;
 }
 $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Conflict.prototype.$tag = 3;
-const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$24$ = { $tag: 0 };
-function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$24$(param0, param1) {
+const $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$28$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$28$(param0, param1) {
   this._0 = param0;
   this._1 = param1;
 }
-$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$24$.prototype.$tag = 1;
+$64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$28$.prototype.$tag = 1;
 function $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$T(param0) {
   this._0 = param0;
 }
@@ -611,6 +644,101 @@ function $64$moonbitlang$47$yacc$47$lib$47$codegen$47$gen_mbt$46$CodegenDecision
   this._2 = param2;
 }
 $64$moonbitlang$47$yacc$47$lib$47$codegen$47$gen_mbt$46$CodegenDecision$ReduceNoLookahead.prototype.$tag = 3;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemIdent$Dollar(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemIdent$Dollar.prototype.$tag = 0;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemIdent$Name(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemIdent$Name.prototype.$tag = 1;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$Dollar(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$Dollar.prototype.$tag = 0;
+const $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$StartPos = { $tag: 1 };
+const $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPos = { $tag: 2 };
+const $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$Loc = { $tag: 3 };
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$StartPosOf(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$StartPosOf.prototype.$tag = 4;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPosOf(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPosOf.prototype.$tag = 5;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$LocOf(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$LocOf.prototype.$tag = 6;
+const $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$SymbolStartPos = { $tag: 7 };
+const $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$Sloc = { $tag: 8 };
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Start(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Start.prototype.$tag = 0;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Token(param0, param1) {
+  this._0 = param0;
+  this._1 = param1;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Token.prototype.$tag = 1;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Token1(param0, param1, param2) {
+  this._0 = param0;
+  this._1 = param1;
+  this._2 = param2;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Token1.prototype.$tag = 2;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Type(param0, param1) {
+  this._0 = param0;
+  this._1 = param1;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Type.prototype.$tag = 3;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Derive(param0, param1) {
+  this._0 = param0;
+  this._1 = param1;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Derive.prototype.$tag = 4;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Position(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Position.prototype.$tag = 5;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Left(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Left.prototype.$tag = 6;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Right(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Right.prototype.$tag = 7;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Nonassoc(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Nonassoc.prototype.$tag = 8;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemDesc$Token(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemDesc$Token.prototype.$tag = 0;
+function $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemDesc$RuleCall(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemDesc$RuleCall.prototype.$tag = 1;
+const $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Continue$29$ = { $tag: 0 };
+function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Break$29$(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Break$29$.prototype.$tag = 1;
+function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Return$29$(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Return$29$.prototype.$tag = 2;
+function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Error$29$(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$core$47$builtin$46$ForeachResult$Error$29$.prototype.$tag = 3;
+function $64$moonbitlang$47$core$47$builtin$46$ForeachResult$JumpOuter$29$(param0) {
+  this._0 = param0;
+}
+$64$moonbitlang$47$core$47$builtin$46$ForeachResult$JumpOuter$29$.prototype.$tag = 4;
 function $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$Data(param0) {
   this._0 = param0;
 }
@@ -653,9 +781,6 @@ function Error$$to_string(_e) {
     case 15: {
       return "moonbitlang/yacc/lib/parser.YYObj__immut_list_T_ClauseItem_.YYObj__immut_list_T_ClauseItem_";
     }
-    case 1: {
-      return moonbitlang$core$builtin$$Show$to_string$0$(_e);
-    }
     case 22: {
       return "moonbitlang/yacc/lib/parser.ParseError.UnexpectedToken";
     }
@@ -667,6 +792,9 @@ function Error$$to_string(_e) {
     }
     case 7: {
       return "moonbitlang/yacc/lib/parser.YYObj_ParserSpec.YYObj_ParserSpec";
+    }
+    case 1: {
+      return moonbitlang$core$builtin$$Show$to_string$0$(_e);
     }
     case 19: {
       return "moonbitlang/yacc/lib/parser.YYObj_ClauseItem.YYObj_ClauseItem";
@@ -861,11 +989,65 @@ function moonbitlang$core$strconv$$check_and_consume_base(view, base) {
             break _L;
           }
         }
-        return base === 0 || base === 16 ? new Result$Ok$0$({ _0: 16, _1: rest$4, _2: true }) : moonbitlang$core$strconv$$base_err$6$();
+        let _tmp;
+        switch (base) {
+          case 0: {
+            _tmp = true;
+            break;
+          }
+          case 16: {
+            _tmp = true;
+            break;
+          }
+          default: {
+            _tmp = false;
+          }
+        }
+        if (_tmp) {
+          return new Result$Ok$0$({ _0: 16, _1: rest$4, _2: true });
+        } else {
+          return moonbitlang$core$strconv$$base_err$6$();
+        }
       }
-      return base === 0 || base === 8 ? new Result$Ok$0$({ _0: 8, _1: rest$3, _2: true }) : moonbitlang$core$strconv$$base_err$6$();
+      let _tmp;
+      switch (base) {
+        case 0: {
+          _tmp = true;
+          break;
+        }
+        case 8: {
+          _tmp = true;
+          break;
+        }
+        default: {
+          _tmp = false;
+        }
+      }
+      if (_tmp) {
+        return new Result$Ok$0$({ _0: 8, _1: rest$3, _2: true });
+      } else {
+        return moonbitlang$core$strconv$$base_err$6$();
+      }
     }
-    return base === 0 || base === 2 ? new Result$Ok$0$({ _0: 2, _1: rest$2, _2: true }) : moonbitlang$core$strconv$$base_err$6$();
+    let _tmp;
+    switch (base) {
+      case 0: {
+        _tmp = true;
+        break;
+      }
+      case 2: {
+        _tmp = true;
+        break;
+      }
+      default: {
+        _tmp = false;
+      }
+    }
+    if (_tmp) {
+      return new Result$Ok$0$({ _0: 2, _1: rest$2, _2: true });
+    } else {
+      return moonbitlang$core$strconv$$base_err$6$();
+    }
   }
   if (base === 0) {
     return new Result$Ok$0$({ _0: 10, _1: rest, _2: false });
@@ -1148,6 +1330,34 @@ function moonbitlang$core$builtin$$Show$output$11$(self, logger) {
   const _x = _StrConvError._0;
   logger.method_0(logger.self, _x);
 }
+function moonbitlang$core$bytes$$Bytes$from_array(arr) {
+  return moonbitlang$core$bytes$$Bytes$makei(arr.length, (i) => moonbitlang$core$array$$Array$op_get$12$(arr, i));
+}
+function moonbitlang$core$bytes$$from_array(arr) {
+  return moonbitlang$core$bytes$$Bytes$makei(arr.length, (i) => moonbitlang$core$array$$Array$op_get$12$(arr, i));
+}
+function moonbitlang$core$bytes$$Bytes$from_iter(iter) {
+  return moonbitlang$core$bytes$$from_array(moonbitlang$core$builtin$$Iter$collect$12$(iter));
+}
+function moonbitlang$core$bytes$$Bytes$iter(self) {
+  return moonbitlang$core$builtin$$Iter$new$12$((yield_) => {
+    let _tmp = 0;
+    let _tmp$2 = self.length;
+    while (true) {
+      const i = _tmp;
+      const len = _tmp$2;
+      if (i < len) {
+        if (moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(self[i]), 0)) {
+          return 0;
+        }
+        _tmp = i + 1 | 0;
+        continue;
+      } else {
+        return 1;
+      }
+    }
+  });
+}
 function moonbitlang$core$string$$is_leading_surrogate(c) {
   return 55296 <= c && c <= 56319;
 }
@@ -1181,7 +1391,7 @@ function moonbitlang$core$string$$String$index_at(self, offset_by, start) {
     }
     return char_count < offset_by || utf16_offset > str_len ? undefined : utf16_offset;
   } else {
-    return moonbitlang$core$builtin$$abort$12$("Invalid start index");
+    return moonbitlang$core$builtin$$abort$14$("Invalid start index");
   }
 }
 function moonbitlang$core$string$$String$index_at_rev(self, offset_by, end) {
@@ -1278,105 +1488,31 @@ function moonbitlang$core$string$$StringView$length_ge(self, len) {
 }
 function moonbitlang$core$string$$String$op_as_view(self, start, end) {
   const str_len = self.length;
-  let start$2;
-  if (start >= 0) {
-    const _bind = moonbitlang$core$string$$String$index_at(self, start, 0);
-    if (_bind === undefined) {
-      start$2 = moonbitlang$core$builtin$$abort$9$("Invalid start index");
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      start$2 = _x;
-    }
-  } else {
-    const _bind = moonbitlang$core$string$$String$index_at_rev(self, -start, str_len);
-    if (_bind === undefined) {
-      start$2 = moonbitlang$core$builtin$$abort$9$("Invalid start index");
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      start$2 = _x;
-    }
-  }
+  const start$2 = start >= 0 ? moonbitlang$core$option$$Option$unwrap$15$(moonbitlang$core$string$$String$index_at(self, start, 0)) : moonbitlang$core$option$$Option$unwrap$15$(moonbitlang$core$string$$String$index_at_rev(self, -start, str_len));
   let end$2;
   if (end === undefined) {
     end$2 = str_len;
   } else {
     const _Some = end;
     const _x = _Some;
-    if (_x >= 0) {
-      const _bind = moonbitlang$core$string$$String$index_at(self, _x, 0);
-      if (_bind === undefined) {
-        end$2 = moonbitlang$core$builtin$$abort$9$("Invalid end index");
-      } else {
-        const _Some$2 = _bind;
-        const _x$2 = _Some$2;
-        end$2 = _x$2;
-      }
-    } else {
-      const _bind = moonbitlang$core$string$$String$index_at_rev(self, -_x, str_len);
-      if (_bind === undefined) {
-        end$2 = moonbitlang$core$builtin$$abort$9$("Invalid end index");
-      } else {
-        const _Some$2 = _bind;
-        const _x$2 = _Some$2;
-        end$2 = _x$2;
-      }
-    }
+    end$2 = _x >= 0 ? moonbitlang$core$option$$Option$unwrap$15$(moonbitlang$core$string$$String$index_at(self, _x, 0)) : moonbitlang$core$option$$Option$unwrap$15$(moonbitlang$core$string$$String$index_at_rev(self, -_x, str_len));
   }
-  return start$2 >= 0 && (start$2 <= end$2 && end$2 <= str_len) ? { str: self, start: start$2, end: end$2 } : moonbitlang$core$builtin$$abort$13$("Invalid index for View");
+  return start$2 >= 0 && (start$2 <= end$2 && end$2 <= str_len) ? { str: self, start: start$2, end: end$2 } : moonbitlang$core$builtin$$abort$16$("Invalid index for View");
 }
 function moonbitlang$core$string$$String$op_as_view$46$start$46$default() {
   return 0;
 }
 function moonbitlang$core$string$$StringView$op_as_view(self, start, end) {
-  let start$2;
-  if (start >= 0) {
-    const _bind = moonbitlang$core$string$$String$index_at(self.str, start, self.start);
-    if (_bind === undefined) {
-      start$2 = moonbitlang$core$builtin$$abort$9$("Invalid start index");
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      start$2 = _x;
-    }
-  } else {
-    const _bind = moonbitlang$core$string$$String$index_at_rev(self.str, -start, self.end);
-    if (_bind === undefined) {
-      start$2 = moonbitlang$core$builtin$$abort$9$("Invalid start index");
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      start$2 = _x;
-    }
-  }
+  const start$2 = start >= 0 ? moonbitlang$core$option$$Option$unwrap$15$(moonbitlang$core$string$$String$index_at(self.str, start, self.start)) : moonbitlang$core$option$$Option$unwrap$15$(moonbitlang$core$string$$String$index_at_rev(self.str, -start, self.end));
   let end$2;
   if (end === undefined) {
     end$2 = self.end;
   } else {
     const _Some = end;
     const _x = _Some;
-    if (_x >= 0) {
-      const _bind = moonbitlang$core$string$$String$index_at(self.str, _x, self.start);
-      if (_bind === undefined) {
-        end$2 = moonbitlang$core$builtin$$abort$9$("Invalid end index");
-      } else {
-        const _Some$2 = _bind;
-        const _x$2 = _Some$2;
-        end$2 = _x$2;
-      }
-    } else {
-      const _bind = moonbitlang$core$string$$String$index_at_rev(self.str, -_x, self.end);
-      if (_bind === undefined) {
-        end$2 = moonbitlang$core$builtin$$abort$9$("Invalid end index");
-      } else {
-        const _Some$2 = _bind;
-        const _x$2 = _Some$2;
-        end$2 = _x$2;
-      }
-    }
+    end$2 = _x >= 0 ? moonbitlang$core$option$$Option$unwrap$15$(moonbitlang$core$string$$String$index_at(self.str, _x, self.start)) : moonbitlang$core$option$$Option$unwrap$15$(moonbitlang$core$string$$String$index_at_rev(self.str, -_x, self.end));
   }
-  return start$2 >= self.start && (start$2 <= self.end && (end$2 >= self.start && (end$2 <= self.end && start$2 <= end$2))) ? { str: self.str, start: start$2, end: end$2 } : moonbitlang$core$builtin$$abort$13$("Invalid index for View");
+  return start$2 >= self.start && (start$2 <= self.end && (end$2 >= self.start && (end$2 <= self.end && start$2 <= end$2))) ? { str: self.str, start: start$2, end: end$2 } : moonbitlang$core$builtin$$abort$16$("Invalid index for View");
 }
 function moonbitlang$core$string$$code_point_of_surrogate_pair(leading, trailing) {
   return (((Math.imul(leading - 55296 | 0, 1024) | 0) + trailing | 0) - 56320 | 0) + 65536 | 0;
@@ -1410,16 +1546,33 @@ function moonbitlang$core$string$$StringView$op_get(self, index) {
       const c1 = self.str.charCodeAt(utf16_offset);
       if (moonbitlang$core$string$$is_leading_surrogate(c1)) {
         const c2 = self.str.charCodeAt(utf16_offset + 1 | 0);
-        return moonbitlang$core$string$$is_trailing_surrogate(c2) ? moonbitlang$core$string$$code_point_of_surrogate_pair(c1, c2) : moonbitlang$core$builtin$$abort$14$("invalid surrogate pair");
+        return moonbitlang$core$string$$is_trailing_surrogate(c2) ? moonbitlang$core$string$$code_point_of_surrogate_pair(c1, c2) : moonbitlang$core$builtin$$abort$17$("invalid surrogate pair");
       } else {
         return c1;
       }
     } else {
-      return moonbitlang$core$builtin$$abort$14$(`Index out of bounds: cannot access index ${moonbitlang$core$int$$Int$to_string(index)}`);
+      return moonbitlang$core$builtin$$abort$17$(`Index out of bounds: cannot access index ${moonbitlang$core$builtin$$Show$to_string$18$(index)}`);
     }
   } else {
-    return moonbitlang$core$builtin$$abort$14$("Index out of bounds: cannot access negative index");
+    return moonbitlang$core$builtin$$abort$17$("Index out of bounds: cannot access negative index");
   }
+}
+function moonbitlang$core$string$$String$from_array(chars) {
+  const buf = moonbitlang$core$builtin$$StringBuilder$new(Math.imul(chars.length, 4) | 0);
+  const _len = chars.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const c = chars[_i];
+      moonbitlang$core$builtin$$StringBuilder$write_char(buf, c);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return moonbitlang$core$builtin$$StringBuilder$to_string(buf);
 }
 function moonbitlang$core$string$$String$concat(strings, separator) {
   const buf = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
@@ -1488,7 +1641,7 @@ function moonbitlang$core$string$$String$default() {
   return "";
 }
 function moonbitlang$core$string$$String$iter(self) {
-  return moonbitlang$core$builtin$$Iter$new$14$((yield_) => {
+  return moonbitlang$core$builtin$$Iter$new$17$((yield_) => {
     const len = self.length;
     let _tmp = 0;
     while (true) {
@@ -1500,18 +1653,30 @@ function moonbitlang$core$string$$String$iter(self) {
           if (moonbitlang$core$string$$is_trailing_surrogate(c2)) {
             const c = moonbitlang$core$string$$code_point_of_surrogate_pair(c1, c2);
             const _bind = yield_(c);
+            let _tmp$2;
             if (_bind === 1) {
+              _tmp$2 = true;
+            } else {
+              _tmp$2 = false;
+            }
+            if (_tmp$2) {
               _tmp = index + 2 | 0;
               continue;
             } else {
-              return _bind;
+              return 0;
             }
           }
         }
         const _bind = yield_(c1);
+        let _tmp$2;
         if (_bind === 1) {
+          _tmp$2 = true;
         } else {
-          return _bind;
+          _tmp$2 = false;
+        }
+        if (_tmp$2) {
+        } else {
+          return 0;
         }
         _tmp = index + 1 | 0;
         continue;
@@ -1523,18 +1688,18 @@ function moonbitlang$core$string$$String$iter(self) {
 }
 function moonbitlang$core$string$$String$to_array(self) {
   const _bind = moonbitlang$core$string$$String$iter(self);
-  const _bind$2 = moonbitlang$core$array$$Array$new$14$(self.length);
+  const _bind$2 = moonbitlang$core$array$$Array$new$17$(self.length);
   const _acc = { val: _bind$2 };
   _bind((_p) => {
     const rv = _acc.val;
-    moonbitlang$core$array$$Array$push$14$(rv, _p);
+    moonbitlang$core$array$$Array$push$17$(rv, _p);
     _acc.val = rv;
     return 1;
   });
   return _acc.val;
 }
 function moonbitlang$core$string$$String$contains_char(self, c) {
-  return moonbitlang$core$builtin$$Iter$any$14$(moonbitlang$core$string$$String$iter(self), (ch) => ch === c);
+  return moonbitlang$core$builtin$$Iter$any$17$(moonbitlang$core$string$$String$iter(self), (ch) => ch === c);
 }
 function moonbitlang$core$string$$String$trim_end(self, trim_set) {
   const len = self.length;
@@ -1722,12 +1887,12 @@ function moonbitlang$core$string$$String$split(self, seperator) {
       if (start < len) {
         const end = moonbitlang$core$string$$String$index_of(self, seperator, start);
         if (end < 0) {
-          if (moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(moonbitlang$core$string$$String$substring(self, start, undefined)), 0)) {
+          if (moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(moonbitlang$core$string$$String$substring(self, start, undefined)), 0)) {
             return 0;
           }
           return 1;
         }
-        if (moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(moonbitlang$core$string$$String$substring(self, start, end)), 0)) {
+        if (moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(moonbitlang$core$string$$String$substring(self, start, end)), 0)) {
           return 0;
         }
         start = end + sep_len | 0;
@@ -1792,22 +1957,29 @@ function moonbitlang$core$string$$String$repeat(self, n) {
   }
   return moonbitlang$core$builtin$$StringBuilder$to_string(buf);
 }
-function moonbitlang$core$result$$Result$unwrap$16$(self) {
+function moonbitlang$core$result$$Result$unwrap$19$(self) {
   if (self.$tag === 1) {
     const _Ok = self;
     const _x = _Ok._0;
     return _x;
   } else {
-    return moonbitlang$core$builtin$$abort$17$("called `Result::unwrap()` on an `Err` value");
+    return moonbitlang$core$builtin$$abort$20$("called `Result::unwrap()` on an `Err` value");
   }
 }
-function moonbitlang$core$sorted_set$$new$18$() {
-  return { root: undefined, size: $0L };
+function moonbitlang$core$result$$Result$unwrap$21$(self) {
+  if (self.$tag === 1) {
+    const _Ok = self;
+    _Ok._0;
+    return;
+  } else {
+    moonbitlang$core$builtin$$abort$8$("called `Result::unwrap()` on an `Err` value");
+    return;
+  }
 }
 function moonbitlang$core$sorted_set$$new$10$() {
   return { root: undefined, size: $0L };
 }
-function moonbitlang$core$sorted_set$$new$19$() {
+function moonbitlang$core$sorted_set$$new$22$() {
   return { root: undefined, size: $0L };
 }
 function moonbitlang$core$sorted_set$$height$10$(node) {
@@ -1819,16 +1991,7 @@ function moonbitlang$core$sorted_set$$height$10$(node) {
     return _x.height;
   }
 }
-function moonbitlang$core$sorted_set$$height$19$(node) {
-  if (node === undefined) {
-    return 0;
-  } else {
-    const _Some = node;
-    const _x = _Some;
-    return _x.height;
-  }
-}
-function moonbitlang$core$sorted_set$$height$18$(node) {
+function moonbitlang$core$sorted_set$$height$22$(node) {
   if (node === undefined) {
     return 0;
   } else {
@@ -1852,22 +2015,7 @@ function moonbitlang$core$sorted_set$$height_ge$10$(x1, x2) {
     }
   }
 }
-function moonbitlang$core$sorted_set$$height_ge$19$(x1, x2) {
-  if (x2 === undefined) {
-    return true;
-  } else {
-    const _Some = x2;
-    const _x = _Some;
-    if (x1 === undefined) {
-      return false;
-    } else {
-      const _Some$2 = x1;
-      const _x$2 = _Some$2;
-      return _x$2.height >= _x.height;
-    }
-  }
-}
-function moonbitlang$core$sorted_set$$height_ge$18$(x1, x2) {
+function moonbitlang$core$sorted_set$$height_ge$22$(x1, x2) {
   if (x2 === undefined) {
     return true;
   } else {
@@ -1888,118 +2036,87 @@ function moonbitlang$core$sorted_set$$max(x, y) {
 function moonbitlang$core$sorted_set$$Node$update_height$10$(self) {
   self.height = 1 + moonbitlang$core$sorted_set$$max(moonbitlang$core$sorted_set$$height$10$(self.left), moonbitlang$core$sorted_set$$height$10$(self.right)) | 0;
 }
-function moonbitlang$core$sorted_set$$Node$update_height$19$(self) {
-  self.height = 1 + moonbitlang$core$sorted_set$$max(moonbitlang$core$sorted_set$$height$19$(self.left), moonbitlang$core$sorted_set$$height$19$(self.right)) | 0;
-}
-function moonbitlang$core$sorted_set$$Node$update_height$18$(self) {
-  self.height = 1 + moonbitlang$core$sorted_set$$max(moonbitlang$core$sorted_set$$height$18$(self.left), moonbitlang$core$sorted_set$$height$18$(self.right)) | 0;
+function moonbitlang$core$sorted_set$$Node$update_height$22$(self) {
+  self.height = 1 + moonbitlang$core$sorted_set$$max(moonbitlang$core$sorted_set$$height$22$(self.left), moonbitlang$core$sorted_set$$height$22$(self.right)) | 0;
 }
 function moonbitlang$core$sorted_set$$rotate_l$10$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$20$(n.right);
+  const r = moonbitlang$core$option$$Option$unwrap$23$(n.right);
   n.right = r.left;
   r.left = n;
   moonbitlang$core$sorted_set$$Node$update_height$10$(n);
   moonbitlang$core$sorted_set$$Node$update_height$10$(r);
   return r;
 }
-function moonbitlang$core$sorted_set$$rotate_l$19$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$21$(n.right);
+function moonbitlang$core$sorted_set$$rotate_l$22$(n) {
+  const r = moonbitlang$core$option$$Option$unwrap$24$(n.right);
   n.right = r.left;
   r.left = n;
-  moonbitlang$core$sorted_set$$Node$update_height$19$(n);
-  moonbitlang$core$sorted_set$$Node$update_height$19$(r);
-  return r;
-}
-function moonbitlang$core$sorted_set$$rotate_l$18$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$22$(n.right);
-  n.right = r.left;
-  r.left = n;
-  moonbitlang$core$sorted_set$$Node$update_height$18$(n);
-  moonbitlang$core$sorted_set$$Node$update_height$18$(r);
+  moonbitlang$core$sorted_set$$Node$update_height$22$(n);
+  moonbitlang$core$sorted_set$$Node$update_height$22$(r);
   return r;
 }
 function moonbitlang$core$sorted_set$$rotate_r$10$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$20$(n.left);
+  const l = moonbitlang$core$option$$Option$unwrap$23$(n.left);
   n.left = l.right;
   l.right = n;
   moonbitlang$core$sorted_set$$Node$update_height$10$(n);
   moonbitlang$core$sorted_set$$Node$update_height$10$(l);
   return l;
 }
-function moonbitlang$core$sorted_set$$rotate_r$19$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$21$(n.left);
+function moonbitlang$core$sorted_set$$rotate_r$22$(n) {
+  const l = moonbitlang$core$option$$Option$unwrap$24$(n.left);
   n.left = l.right;
   l.right = n;
-  moonbitlang$core$sorted_set$$Node$update_height$19$(n);
-  moonbitlang$core$sorted_set$$Node$update_height$19$(l);
-  return l;
-}
-function moonbitlang$core$sorted_set$$rotate_r$18$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$22$(n.left);
-  n.left = l.right;
-  l.right = n;
-  moonbitlang$core$sorted_set$$Node$update_height$18$(n);
-  moonbitlang$core$sorted_set$$Node$update_height$18$(l);
+  moonbitlang$core$sorted_set$$Node$update_height$22$(n);
+  moonbitlang$core$sorted_set$$Node$update_height$22$(l);
   return l;
 }
 function moonbitlang$core$sorted_set$$rotate_lr$10$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$20$(n.left);
+  const l = moonbitlang$core$option$$Option$unwrap$23$(n.left);
   const v = moonbitlang$core$sorted_set$$rotate_l$10$(l);
   n.left = v;
   return moonbitlang$core$sorted_set$$rotate_r$10$(n);
 }
-function moonbitlang$core$sorted_set$$rotate_lr$19$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$21$(n.left);
-  const v = moonbitlang$core$sorted_set$$rotate_l$19$(l);
+function moonbitlang$core$sorted_set$$rotate_lr$22$(n) {
+  const l = moonbitlang$core$option$$Option$unwrap$24$(n.left);
+  const v = moonbitlang$core$sorted_set$$rotate_l$22$(l);
   n.left = v;
-  return moonbitlang$core$sorted_set$$rotate_r$19$(n);
-}
-function moonbitlang$core$sorted_set$$rotate_lr$18$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$22$(n.left);
-  const v = moonbitlang$core$sorted_set$$rotate_l$18$(l);
-  n.left = v;
-  return moonbitlang$core$sorted_set$$rotate_r$18$(n);
+  return moonbitlang$core$sorted_set$$rotate_r$22$(n);
 }
 function moonbitlang$core$sorted_set$$rotate_rl$10$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$20$(n.right);
+  const r = moonbitlang$core$option$$Option$unwrap$23$(n.right);
   const v = moonbitlang$core$sorted_set$$rotate_r$10$(r);
   n.right = v;
   return moonbitlang$core$sorted_set$$rotate_l$10$(n);
 }
-function moonbitlang$core$sorted_set$$rotate_rl$19$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$21$(n.right);
-  const v = moonbitlang$core$sorted_set$$rotate_r$19$(r);
+function moonbitlang$core$sorted_set$$rotate_rl$22$(n) {
+  const r = moonbitlang$core$option$$Option$unwrap$24$(n.right);
+  const v = moonbitlang$core$sorted_set$$rotate_r$22$(r);
   n.right = v;
-  return moonbitlang$core$sorted_set$$rotate_l$19$(n);
+  return moonbitlang$core$sorted_set$$rotate_l$22$(n);
 }
-function moonbitlang$core$sorted_set$$rotate_rl$18$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$22$(n.right);
-  const v = moonbitlang$core$sorted_set$$rotate_r$18$(r);
-  n.right = v;
-  return moonbitlang$core$sorted_set$$rotate_l$18$(n);
-}
-function moonbitlang$core$sorted_set$$balance$19$(root) {
+function moonbitlang$core$sorted_set$$balance$22$(root) {
   const l = root.left;
   const r = root.right;
-  const hl = moonbitlang$core$sorted_set$$height$19$(l);
-  const hr = moonbitlang$core$sorted_set$$height$19$(r);
+  const hl = moonbitlang$core$sorted_set$$height$22$(l);
+  const hr = moonbitlang$core$sorted_set$$height$22$(r);
   let new_root;
   if (hl > (hr + 1 | 0)) {
-    const _bind = moonbitlang$core$option$$Option$unwrap$21$(l);
+    const _bind = moonbitlang$core$option$$Option$unwrap$24$(l);
     const _x = _bind.left;
     const _x$2 = _bind.right;
-    new_root = moonbitlang$core$sorted_set$$height_ge$19$(_x, _x$2) ? moonbitlang$core$sorted_set$$rotate_r$19$(root) : moonbitlang$core$sorted_set$$rotate_lr$19$(root);
+    new_root = moonbitlang$core$sorted_set$$height_ge$22$(_x, _x$2) ? moonbitlang$core$sorted_set$$rotate_r$22$(root) : moonbitlang$core$sorted_set$$rotate_lr$22$(root);
   } else {
     if (hr > (hl + 1 | 0)) {
-      const _bind = moonbitlang$core$option$$Option$unwrap$21$(r);
+      const _bind = moonbitlang$core$option$$Option$unwrap$24$(r);
       const _x = _bind.left;
       const _x$2 = _bind.right;
-      new_root = moonbitlang$core$sorted_set$$height_ge$19$(_x$2, _x) ? moonbitlang$core$sorted_set$$rotate_l$19$(root) : moonbitlang$core$sorted_set$$rotate_rl$19$(root);
+      new_root = moonbitlang$core$sorted_set$$height_ge$22$(_x$2, _x) ? moonbitlang$core$sorted_set$$rotate_l$22$(root) : moonbitlang$core$sorted_set$$rotate_rl$22$(root);
     } else {
       new_root = root;
     }
   }
-  moonbitlang$core$sorted_set$$Node$update_height$19$(new_root);
+  moonbitlang$core$sorted_set$$Node$update_height$22$(new_root);
   return new_root;
 }
 function moonbitlang$core$sorted_set$$balance$10$(root) {
@@ -2009,13 +2126,13 @@ function moonbitlang$core$sorted_set$$balance$10$(root) {
   const hr = moonbitlang$core$sorted_set$$height$10$(r);
   let new_root;
   if (hl > (hr + 1 | 0)) {
-    const _bind = moonbitlang$core$option$$Option$unwrap$20$(l);
+    const _bind = moonbitlang$core$option$$Option$unwrap$23$(l);
     const _x = _bind.left;
     const _x$2 = _bind.right;
     new_root = moonbitlang$core$sorted_set$$height_ge$10$(_x, _x$2) ? moonbitlang$core$sorted_set$$rotate_r$10$(root) : moonbitlang$core$sorted_set$$rotate_lr$10$(root);
   } else {
     if (hr > (hl + 1 | 0)) {
-      const _bind = moonbitlang$core$option$$Option$unwrap$20$(r);
+      const _bind = moonbitlang$core$option$$Option$unwrap$23$(r);
       const _x = _bind.left;
       const _x$2 = _bind.right;
       new_root = moonbitlang$core$sorted_set$$height_ge$10$(_x$2, _x) ? moonbitlang$core$sorted_set$$rotate_l$10$(root) : moonbitlang$core$sorted_set$$rotate_rl$10$(root);
@@ -2026,61 +2143,25 @@ function moonbitlang$core$sorted_set$$balance$10$(root) {
   moonbitlang$core$sorted_set$$Node$update_height$10$(new_root);
   return new_root;
 }
-function moonbitlang$core$sorted_set$$balance$18$(root) {
-  const l = root.left;
-  const r = root.right;
-  const hl = moonbitlang$core$sorted_set$$height$18$(l);
-  const hr = moonbitlang$core$sorted_set$$height$18$(r);
-  let new_root;
-  if (hl > (hr + 1 | 0)) {
-    const _bind = moonbitlang$core$option$$Option$unwrap$22$(l);
-    const _x = _bind.left;
-    const _x$2 = _bind.right;
-    new_root = moonbitlang$core$sorted_set$$height_ge$18$(_x, _x$2) ? moonbitlang$core$sorted_set$$rotate_r$18$(root) : moonbitlang$core$sorted_set$$rotate_lr$18$(root);
-  } else {
-    if (hr > (hl + 1 | 0)) {
-      const _bind = moonbitlang$core$option$$Option$unwrap$22$(r);
-      const _x = _bind.left;
-      const _x$2 = _bind.right;
-      new_root = moonbitlang$core$sorted_set$$height_ge$18$(_x$2, _x) ? moonbitlang$core$sorted_set$$rotate_l$18$(root) : moonbitlang$core$sorted_set$$rotate_rl$18$(root);
-    } else {
-      new_root = root;
-    }
-  }
-  moonbitlang$core$sorted_set$$Node$update_height$18$(new_root);
-  return new_root;
-}
-function moonbitlang$core$sorted_set$$new_node$18$(value, left, right, height) {
-  return { value: value, left: left, right: right, height: height };
-}
-function moonbitlang$core$sorted_set$$new_node$19$(value, left, right, height) {
+function moonbitlang$core$sorted_set$$new_node$22$(value, left, right, height) {
   return { value: value, left: left, right: right, height: height };
 }
 function moonbitlang$core$sorted_set$$new_node$10$(value, left, right, height) {
   return { value: value, left: left, right: right, height: height };
 }
-function moonbitlang$core$sorted_set$$new_node$46$left$46$default$18$() {
-  return undefined;
-}
-function moonbitlang$core$sorted_set$$new_node$46$left$46$default$19$() {
+function moonbitlang$core$sorted_set$$new_node$46$left$46$default$22$() {
   return undefined;
 }
 function moonbitlang$core$sorted_set$$new_node$46$left$46$default$10$() {
   return undefined;
 }
-function moonbitlang$core$sorted_set$$new_node$46$right$46$default$18$() {
-  return undefined;
-}
-function moonbitlang$core$sorted_set$$new_node$46$right$46$default$19$() {
+function moonbitlang$core$sorted_set$$new_node$46$right$46$default$22$() {
   return undefined;
 }
 function moonbitlang$core$sorted_set$$new_node$46$right$46$default$10$() {
   return undefined;
 }
-function moonbitlang$core$sorted_set$$new_node$46$height$46$default$18$() {
-  return 1;
-}
-function moonbitlang$core$sorted_set$$new_node$46$height$46$default$19$() {
+function moonbitlang$core$sorted_set$$new_node$46$height$46$default$22$() {
   return 1;
 }
 function moonbitlang$core$sorted_set$$new_node$46$height$46$default$10$() {
@@ -2115,13 +2196,13 @@ function moonbitlang$core$sorted_set$$add_node$10$(root, value) {
     }
   }
 }
-function moonbitlang$core$sorted_set$$add_node$19$(root, value) {
+function moonbitlang$core$sorted_set$$add_node$22$(root, value) {
   if (root === undefined) {
-    return { _0: moonbitlang$core$sorted_set$$new_node$19$(value, moonbitlang$core$sorted_set$$new_node$46$left$46$default$19$(), moonbitlang$core$sorted_set$$new_node$46$right$46$default$19$(), moonbitlang$core$sorted_set$$new_node$46$height$46$default$19$()), _1: true };
+    return { _0: moonbitlang$core$sorted_set$$new_node$22$(value, moonbitlang$core$sorted_set$$new_node$46$left$46$default$22$(), moonbitlang$core$sorted_set$$new_node$46$right$46$default$22$(), moonbitlang$core$sorted_set$$new_node$46$height$46$default$22$()), _1: true };
   } else {
     const _Some = root;
     const _x = _Some;
-    const comp = moonbitlang$core$builtin$$Compare$compare$19$(value, _x.value);
+    const comp = moonbitlang$core$builtin$$Compare$compare$22$(value, _x.value);
     if (comp === 0) {
       _x.value = value;
       return { _0: _x, _1: false };
@@ -2129,69 +2210,26 @@ function moonbitlang$core$sorted_set$$add_node$19$(root, value) {
       const l = _x.left;
       const r = _x.right;
       if (comp < 0) {
-        const _bind = moonbitlang$core$sorted_set$$add_node$19$(l, value);
+        const _bind = moonbitlang$core$sorted_set$$add_node$22$(l, value);
         const _x$2 = _bind._0;
         const _x$3 = _bind._1;
         _x.left = _x$2;
-        return { _0: moonbitlang$core$sorted_set$$balance$19$(_x), _1: _x$3 };
+        return { _0: moonbitlang$core$sorted_set$$balance$22$(_x), _1: _x$3 };
       } else {
-        const _bind = moonbitlang$core$sorted_set$$add_node$19$(r, value);
+        const _bind = moonbitlang$core$sorted_set$$add_node$22$(r, value);
         const _x$2 = _bind._0;
         const _x$3 = _bind._1;
         _x.right = _x$2;
-        return { _0: moonbitlang$core$sorted_set$$balance$19$(_x), _1: _x$3 };
+        return { _0: moonbitlang$core$sorted_set$$balance$22$(_x), _1: _x$3 };
       }
     }
   }
 }
-function moonbitlang$core$sorted_set$$add_node$18$(root, value) {
-  if (root === undefined) {
-    return { _0: moonbitlang$core$sorted_set$$new_node$18$(value, moonbitlang$core$sorted_set$$new_node$46$left$46$default$18$(), moonbitlang$core$sorted_set$$new_node$46$right$46$default$18$(), moonbitlang$core$sorted_set$$new_node$46$height$46$default$18$()), _1: true };
-  } else {
-    const _Some = root;
-    const _x = _Some;
-    const comp = moonbitlang$yacc$lib$grm$$Nonterminal$compare(value, _x.value);
-    if (comp === 0) {
-      _x.value = value;
-      return { _0: _x, _1: false };
-    } else {
-      const l = _x.left;
-      const r = _x.right;
-      if (comp < 0) {
-        const _bind = moonbitlang$core$sorted_set$$add_node$18$(l, value);
-        const _x$2 = _bind._0;
-        const _x$3 = _bind._1;
-        _x.left = _x$2;
-        return { _0: moonbitlang$core$sorted_set$$balance$18$(_x), _1: _x$3 };
-      } else {
-        const _bind = moonbitlang$core$sorted_set$$add_node$18$(r, value);
-        const _x$2 = _bind._0;
-        const _x$3 = _bind._1;
-        _x.right = _x$2;
-        return { _0: moonbitlang$core$sorted_set$$balance$18$(_x), _1: _x$3 };
-      }
-    }
-  }
-}
-function moonbitlang$core$sorted_set$$T$add$18$(self, value) {
-  const _bind = moonbitlang$core$sorted_set$$add_node$18$(self.root, value);
+function moonbitlang$core$sorted_set$$T$add$22$(self, value) {
+  const _bind = moonbitlang$core$sorted_set$$add_node$22$(self.root, value);
   const _x = _bind._0;
   const _x$2 = _bind._1;
-  if (moonbitlang$core$builtin$$op_notequal$23$(self.root, _x)) {
-    self.root = _x;
-  }
-  if (_x$2) {
-    self.size = moonbitlang$core$int64$$Int64$op_add(self.size, $1L);
-    return;
-  } else {
-    return;
-  }
-}
-function moonbitlang$core$sorted_set$$T$add$19$(self, value) {
-  const _bind = moonbitlang$core$sorted_set$$add_node$19$(self.root, value);
-  const _x = _bind._0;
-  const _x$2 = _bind._1;
-  if (moonbitlang$core$builtin$$op_notequal$24$(self.root, _x)) {
+  if (moonbitlang$core$builtin$$op_notequal$25$(self.root, _x)) {
     self.root = _x;
   }
   if (_x$2) {
@@ -2205,7 +2243,7 @@ function moonbitlang$core$sorted_set$$T$add$10$(self, value) {
   const _bind = moonbitlang$core$sorted_set$$add_node$10$(self.root, value);
   const _x = _bind._0;
   const _x$2 = _bind._1;
-  if (moonbitlang$core$builtin$$op_notequal$25$(self.root, _x)) {
+  if (moonbitlang$core$builtin$$op_notequal$26$(self.root, _x)) {
     self.root = _x;
   }
   if (_x$2) {
@@ -2215,100 +2253,7 @@ function moonbitlang$core$sorted_set$$T$add$10$(self, value) {
     return;
   }
 }
-function moonbitlang$core$sorted_set$$replace_root_with_min$18$(root, node) {
-  const l = node.left;
-  const r = node.right;
-  if (l === undefined) {
-    root.value = node.value;
-    return r;
-  } else {
-    const _Some = l;
-    const _x = _Some;
-    node.left = moonbitlang$core$sorted_set$$replace_root_with_min$18$(root, _x);
-    return moonbitlang$core$sorted_set$$balance$18$(node);
-  }
-}
-function moonbitlang$core$sorted_set$$delete_node$18$(root, value) {
-  const comp = moonbitlang$yacc$lib$grm$$Nonterminal$compare(value, root.value);
-  if (comp === 0) {
-    const l = root.left;
-    const r = root.right;
-    let n;
-    _L: {
-      _L$2: {
-        if (l === undefined) {
-          if (r === undefined) {
-            break _L$2;
-          } else {
-            n = r;
-          }
-        } else {
-          if (r === undefined) {
-            break _L$2;
-          } else {
-            const _Some = r;
-            const _x = _Some;
-            root.right = moonbitlang$core$sorted_set$$replace_root_with_min$18$(root, _x);
-            n = moonbitlang$core$sorted_set$$balance$18$(root);
-          }
-        }
-        break _L;
-      }
-      n = l;
-    }
-    return { _0: n, _1: true };
-  } else {
-    if (comp < 0) {
-      const _bind = root.left;
-      if (_bind === undefined) {
-        return { _0: root, _1: false };
-      } else {
-        const _Some = _bind;
-        const _x = _Some;
-        const _bind$2 = moonbitlang$core$sorted_set$$delete_node$18$(_x, value);
-        const _x$2 = _bind$2._0;
-        const _x$3 = _bind$2._1;
-        root.left = _x$2;
-        return { _0: moonbitlang$core$sorted_set$$balance$18$(root), _1: _x$3 };
-      }
-    } else {
-      const _bind = root.right;
-      if (_bind === undefined) {
-        return { _0: root, _1: false };
-      } else {
-        const _Some = _bind;
-        const _x = _Some;
-        const _bind$2 = moonbitlang$core$sorted_set$$delete_node$18$(_x, value);
-        const _x$2 = _bind$2._0;
-        const _x$3 = _bind$2._1;
-        root.right = _x$2;
-        return { _0: moonbitlang$core$sorted_set$$balance$18$(root), _1: _x$3 };
-      }
-    }
-  }
-}
-function moonbitlang$core$sorted_set$$T$remove$18$(self, value) {
-  const _bind = self.root;
-  if (_bind === undefined) {
-    return;
-  } else {
-    const _Some = _bind;
-    const _x = _Some;
-    const _bind$2 = moonbitlang$core$sorted_set$$delete_node$18$(_x, value);
-    const _x$2 = _bind$2._0;
-    const _x$3 = _bind$2._1;
-    if (moonbitlang$core$builtin$$op_notequal$23$(self.root, _x$2)) {
-      self.root = _x$2;
-    }
-    if (_x$3) {
-      self.size = moonbitlang$core$int64$$Int64$op_sub(self.size, $1L);
-      return;
-    } else {
-      return;
-    }
-  }
-}
-function moonbitlang$core$sorted_set$$T$contains$19$(self, value) {
+function moonbitlang$core$sorted_set$$T$contains$22$(self, value) {
   let _tmp = self.root;
   let _tmp$2 = value;
   while (true) {
@@ -2319,7 +2264,7 @@ function moonbitlang$core$sorted_set$$T$contains$19$(self, value) {
     } else {
       const _Some = _param;
       const _x = _Some;
-      const compare_result = moonbitlang$core$builtin$$Compare$compare$19$(_param$2, _x.value);
+      const compare_result = moonbitlang$core$builtin$$Compare$compare$22$(_param$2, _x.value);
       if (compare_result === 0) {
         return true;
       } else {
@@ -2347,10 +2292,10 @@ function moonbitlang$core$sorted_set$$Node$iter$10$(self) {
       const _x$4 = _Some;
       res = moonbitlang$core$builtin$$Iter$run$10$(moonbitlang$core$sorted_set$$Node$iter$10$(_x$4), yield_);
     }
-    if (moonbitlang$core$builtin$$Eq$op_equal$15$(res, 0)) {
+    if (moonbitlang$core$builtin$$Eq$op_equal$13$(res, 0)) {
       return 0;
     } else {
-      if (moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x$2), 0)) {
+      if (moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(_x$2), 0)) {
         return 0;
       } else {
         if (_x$3 === undefined) {
@@ -2359,36 +2304,6 @@ function moonbitlang$core$sorted_set$$Node$iter$10$(self) {
           const _Some = _x$3;
           const _x$4 = _Some;
           return moonbitlang$core$builtin$$Iter$run$10$(moonbitlang$core$sorted_set$$Node$iter$10$(_x$4), yield_);
-        }
-      }
-    }
-  });
-}
-function moonbitlang$core$sorted_set$$Node$iter$18$(self) {
-  return moonbitlang$core$builtin$$Iter$new$18$((yield_) => {
-    const _x = self.left;
-    const _x$2 = self.value;
-    const _x$3 = self.right;
-    let res;
-    if (_x === undefined) {
-      res = 1;
-    } else {
-      const _Some = _x;
-      const _x$4 = _Some;
-      res = moonbitlang$core$builtin$$Iter$run$18$(moonbitlang$core$sorted_set$$Node$iter$18$(_x$4), yield_);
-    }
-    if (moonbitlang$core$builtin$$Eq$op_equal$15$(res, 0)) {
-      return 0;
-    } else {
-      if (moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x$2), 0)) {
-        return 0;
-      } else {
-        if (_x$3 === undefined) {
-          return 1;
-        } else {
-          const _Some = _x$3;
-          const _x$4 = _Some;
-          return moonbitlang$core$builtin$$Iter$run$18$(moonbitlang$core$sorted_set$$Node$iter$18$(_x$4), yield_);
         }
       }
     }
@@ -2406,37 +2321,11 @@ function moonbitlang$core$sorted_set$$T$iter$10$(self) {
     }
   });
 }
-function moonbitlang$core$sorted_set$$T$iter$18$(self) {
-  return moonbitlang$core$builtin$$Iter$new$18$((yield_) => {
-    const _bind = self.root;
-    if (_bind === undefined) {
-      return 1;
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      return moonbitlang$core$builtin$$Iter$run$18$(moonbitlang$core$sorted_set$$Node$iter$18$(_x), yield_);
-    }
-  });
-}
-function moonbitlang$core$sorted_set$$from_iter$18$(iter) {
-  const s = moonbitlang$core$sorted_set$$new$18$();
-  iter((_p) => {
-    moonbitlang$core$sorted_set$$T$add$18$(s, _p);
-    return 1;
-  });
-  return s;
-}
 function moonbitlang$core$sorted_set$$Node$op_equal$10$(self, other) {
   return self.value === other.value;
 }
-function moonbitlang$core$sorted_set$$Node$op_equal$19$(self, other) {
-  return moonbitlang$core$builtin$$Eq$op_equal$19$(self.value, other.value);
-}
-function moonbitlang$core$sorted_set$$Node$op_equal$18$(self, other) {
-  return moonbitlang$yacc$lib$grm$$Nonterminal$op_equal(self.value, other.value);
-}
-function moonbitlang$core$ref$$new$26$(x) {
-  return { val: x };
+function moonbitlang$core$sorted_set$$Node$op_equal$22$(self, other) {
+  return moonbitlang$core$builtin$$Eq$op_equal$22$(self.value, other.value);
 }
 function moonbitlang$core$ref$$new$27$(x) {
   return { val: x };
@@ -2448,6 +2337,9 @@ function moonbitlang$core$ref$$new$29$(x) {
   return { val: x };
 }
 function moonbitlang$core$ref$$new$30$(x) {
+  return { val: x };
+}
+function moonbitlang$core$ref$$new$31$(x) {
   return { val: x };
 }
 function moonbitlang$core$ref$$new$10$(x) {
@@ -2467,21 +2359,6 @@ function moonbitlang$core$array$$get_limit(len) {
   }
   return limit;
 }
-function moonbitlang$core$array$$ArrayView$rev_inplace$31$(self) {
-  const mid_len = moonbitlang$core$array$$ArrayView$length$31$(self) / 2 | 0;
-  let _tmp = 0;
-  while (true) {
-    const i = _tmp;
-    if (i < mid_len) {
-      const j = (moonbitlang$core$array$$ArrayView$length$31$(self) - i | 0) - 1 | 0;
-      moonbitlang$core$array$$ArrayView$swap$31$(self, i, j);
-      _tmp = i + 1 | 0;
-      continue;
-    } else {
-      return;
-    }
-  }
-}
 function moonbitlang$core$array$$ArrayView$rev_inplace$32$(self) {
   const mid_len = moonbitlang$core$array$$ArrayView$length$32$(self) / 2 | 0;
   let _tmp = 0;
@@ -2490,6 +2367,21 @@ function moonbitlang$core$array$$ArrayView$rev_inplace$32$(self) {
     if (i < mid_len) {
       const j = (moonbitlang$core$array$$ArrayView$length$32$(self) - i | 0) - 1 | 0;
       moonbitlang$core$array$$ArrayView$swap$32$(self, i, j);
+      _tmp = i + 1 | 0;
+      continue;
+    } else {
+      return;
+    }
+  }
+}
+function moonbitlang$core$array$$ArrayView$rev_inplace$33$(self) {
+  const mid_len = moonbitlang$core$array$$ArrayView$length$33$(self) / 2 | 0;
+  let _tmp = 0;
+  while (true) {
+    const i = _tmp;
+    if (i < mid_len) {
+      const j = (moonbitlang$core$array$$ArrayView$length$33$(self) - i | 0) - 1 | 0;
+      moonbitlang$core$array$$ArrayView$swap$33$(self, i, j);
       _tmp = i + 1 | 0;
       continue;
     } else {
@@ -2509,9 +2401,15 @@ function moonbitlang$core$array$$ArrayView$iter$10$(self) {
       if (_i < _len) {
         const v = self.buf[self.start + _i | 0];
         const _bind = yield_(v);
+        let _tmp$2;
         if (_bind === 1) {
+          _tmp$2 = true;
         } else {
-          return _bind;
+          _tmp$2 = false;
+        }
+        if (_tmp$2) {
+        } else {
+          return 0;
         }
         _tmp = _i + 1 | 0;
         continue;
@@ -2521,20 +2419,20 @@ function moonbitlang$core$array$$ArrayView$iter$10$(self) {
     }
   });
 }
-function moonbitlang$core$array$$FixedArray$copy$33$(self) {
+function moonbitlang$core$array$$FixedArray$copy$34$(self) {
   const len = self.length;
   if (len === 0) {
     return [];
   } else {
     const arr = $make_array_len_and_init(len, self[0]);
-    moonbitlang$core$array$$FixedArray$unsafe_blit$33$(arr, 0, self, 0, len);
+    moonbitlang$core$array$$FixedArray$unsafe_blit$34$(arr, 0, self, 0, len);
     return arr;
   }
 }
 function moonbitlang$core$array$$Array$copy$9$(self) {
   return moonbitlang$core$array$$JSArray$copy(self);
 }
-function moonbitlang$core$array$$FixedArray$makei$34$(length, value) {
+function moonbitlang$core$array$$FixedArray$makei$35$(length, value) {
   if (length <= 0) {
     return [];
   } else {
@@ -2551,29 +2449,6 @@ function moonbitlang$core$array$$FixedArray$makei$34$(length, value) {
       }
     }
     return array;
-  }
-}
-function moonbitlang$core$array$$bubble_sort_by$31$(arr, cmp) {
-  let _tmp = 1;
-  while (true) {
-    const i = _tmp;
-    if (i < moonbitlang$core$array$$ArrayView$length$31$(arr)) {
-      let _tmp$2 = i;
-      while (true) {
-        const j = _tmp$2;
-        if (j > 0 && cmp(moonbitlang$core$array$$ArrayView$op_get$31$(arr, j - 1 | 0), moonbitlang$core$array$$ArrayView$op_get$31$(arr, j)) > 0) {
-          moonbitlang$core$array$$ArrayView$swap$31$(arr, j, j - 1 | 0);
-          _tmp$2 = j - 1 | 0;
-          continue;
-        } else {
-          break;
-        }
-      }
-      _tmp = i + 1 | 0;
-      continue;
-    } else {
-      return;
-    }
   }
 }
 function moonbitlang$core$array$$bubble_sort_by$32$(arr, cmp) {
@@ -2599,44 +2474,28 @@ function moonbitlang$core$array$$bubble_sort_by$32$(arr, cmp) {
     }
   }
 }
-function moonbitlang$core$array$$choose_pivot_by$31$(arr, cmp) {
-  const len = moonbitlang$core$array$$ArrayView$length$31$(arr);
-  const swaps = { val: 0 };
-  const b = Math.imul(len / 4 | 0, 2) | 0;
-  if (len >= 8) {
-    const a = Math.imul(len / 4 | 0, 1) | 0;
-    const c = Math.imul(len / 4 | 0, 3) | 0;
-    const _env = { _0: cmp, _1: arr, _2: swaps };
-    if (len > 50) {
-      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$570(_env, a - 1 | 0, a, a + 1 | 0);
-      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$570(_env, b - 1 | 0, b, b + 1 | 0);
-      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$570(_env, c - 1 | 0, c, c + 1 | 0);
+function moonbitlang$core$array$$bubble_sort_by$33$(arr, cmp) {
+  let _tmp = 1;
+  while (true) {
+    const i = _tmp;
+    if (i < moonbitlang$core$array$$ArrayView$length$33$(arr)) {
+      let _tmp$2 = i;
+      while (true) {
+        const j = _tmp$2;
+        if (j > 0 && cmp(moonbitlang$core$array$$ArrayView$op_get$33$(arr, j - 1 | 0), moonbitlang$core$array$$ArrayView$op_get$33$(arr, j)) > 0) {
+          moonbitlang$core$array$$ArrayView$swap$33$(arr, j, j - 1 | 0);
+          _tmp$2 = j - 1 | 0;
+          continue;
+        } else {
+          break;
+        }
+      }
+      _tmp = i + 1 | 0;
+      continue;
+    } else {
+      return;
     }
-    moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$570(_env, a, b, c);
   }
-  if (swaps.val === 12) {
-    moonbitlang$core$array$$ArrayView$rev_inplace$31$(arr);
-    return { _0: (len - b | 0) - 1 | 0, _1: true };
-  } else {
-    return { _0: b, _1: swaps.val === 0 };
-  }
-}
-function moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$569(_env, a, b) {
-  const swaps = _env._2;
-  const arr = _env._1;
-  const cmp = _env._0;
-  if (cmp(moonbitlang$core$array$$ArrayView$op_get$31$(arr, a), moonbitlang$core$array$$ArrayView$op_get$31$(arr, b)) > 0) {
-    moonbitlang$core$array$$ArrayView$swap$31$(arr, a, b);
-    swaps.val = swaps.val + 1 | 0;
-    return;
-  } else {
-    return;
-  }
-}
-function moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$570(_env, a, b, c) {
-  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$569(_env, a, b);
-  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$569(_env, b, c);
-  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$569(_env, a, b);
 }
 function moonbitlang$core$array$$choose_pivot_by$32$(arr, cmp) {
   const len = moonbitlang$core$array$$ArrayView$length$32$(arr);
@@ -2647,11 +2506,11 @@ function moonbitlang$core$array$$choose_pivot_by$32$(arr, cmp) {
     const c = Math.imul(len / 4 | 0, 3) | 0;
     const _env = { _0: cmp, _1: arr, _2: swaps };
     if (len > 50) {
-      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$590(_env, a - 1 | 0, a, a + 1 | 0);
-      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$590(_env, b - 1 | 0, b, b + 1 | 0);
-      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$590(_env, c - 1 | 0, c, c + 1 | 0);
+      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$456(_env, a - 1 | 0, a, a + 1 | 0);
+      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$456(_env, b - 1 | 0, b, b + 1 | 0);
+      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$456(_env, c - 1 | 0, c, c + 1 | 0);
     }
-    moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$590(_env, a, b, c);
+    moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$456(_env, a, b, c);
   }
   if (swaps.val === 12) {
     moonbitlang$core$array$$ArrayView$rev_inplace$32$(arr);
@@ -2660,7 +2519,7 @@ function moonbitlang$core$array$$choose_pivot_by$32$(arr, cmp) {
     return { _0: b, _1: swaps.val === 0 };
   }
 }
-function moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$589(_env, a, b) {
+function moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$455(_env, a, b) {
   const swaps = _env._2;
   const arr = _env._1;
   const cmp = _env._0;
@@ -2672,31 +2531,49 @@ function moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$589(_env, a, b) {
     return;
   }
 }
-function moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$590(_env, a, b, c) {
-  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$589(_env, a, b);
-  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$589(_env, b, c);
-  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$589(_env, a, b);
+function moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$456(_env, a, b, c) {
+  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$455(_env, a, b);
+  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$455(_env, b, c);
+  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$455(_env, a, b);
 }
-function moonbitlang$core$array$$sift_down_by$31$(arr, index, cmp) {
-  let index$2 = index;
-  const len = moonbitlang$core$array$$ArrayView$length$31$(arr);
-  let child = (Math.imul(index$2, 2) | 0) + 1 | 0;
-  while (true) {
-    if (child < len) {
-      if ((child + 1 | 0) < len && cmp(moonbitlang$core$array$$ArrayView$op_get$31$(arr, child), moonbitlang$core$array$$ArrayView$op_get$31$(arr, child + 1 | 0)) < 0) {
-        child = child + 1 | 0;
-      }
-      if (cmp(moonbitlang$core$array$$ArrayView$op_get$31$(arr, index$2), moonbitlang$core$array$$ArrayView$op_get$31$(arr, child)) >= 0) {
-        return undefined;
-      }
-      moonbitlang$core$array$$ArrayView$swap$31$(arr, index$2, child);
-      index$2 = child;
-      child = (Math.imul(index$2, 2) | 0) + 1 | 0;
-      continue;
-    } else {
-      return;
+function moonbitlang$core$array$$choose_pivot_by$33$(arr, cmp) {
+  const len = moonbitlang$core$array$$ArrayView$length$33$(arr);
+  const swaps = { val: 0 };
+  const b = Math.imul(len / 4 | 0, 2) | 0;
+  if (len >= 8) {
+    const a = Math.imul(len / 4 | 0, 1) | 0;
+    const c = Math.imul(len / 4 | 0, 3) | 0;
+    const _env = { _0: cmp, _1: arr, _2: swaps };
+    if (len > 50) {
+      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$476(_env, a - 1 | 0, a, a + 1 | 0);
+      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$476(_env, b - 1 | 0, b, b + 1 | 0);
+      moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$476(_env, c - 1 | 0, c, c + 1 | 0);
     }
+    moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$476(_env, a, b, c);
   }
+  if (swaps.val === 12) {
+    moonbitlang$core$array$$ArrayView$rev_inplace$33$(arr);
+    return { _0: (len - b | 0) - 1 | 0, _1: true };
+  } else {
+    return { _0: b, _1: swaps.val === 0 };
+  }
+}
+function moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$475(_env, a, b) {
+  const swaps = _env._2;
+  const arr = _env._1;
+  const cmp = _env._0;
+  if (cmp(moonbitlang$core$array$$ArrayView$op_get$33$(arr, a), moonbitlang$core$array$$ArrayView$op_get$33$(arr, b)) > 0) {
+    moonbitlang$core$array$$ArrayView$swap$33$(arr, a, b);
+    swaps.val = swaps.val + 1 | 0;
+    return;
+  } else {
+    return;
+  }
+}
+function moonbitlang$core$array$$choose_pivot_by$46$sort_3$47$476(_env, a, b, c) {
+  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$475(_env, a, b);
+  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$475(_env, b, c);
+  moonbitlang$core$array$$choose_pivot_by$46$sort_2$47$475(_env, a, b);
 }
 function moonbitlang$core$array$$sift_down_by$32$(arr, index, cmp) {
   let index$2 = index;
@@ -2719,26 +2596,21 @@ function moonbitlang$core$array$$sift_down_by$32$(arr, index, cmp) {
     }
   }
 }
-function moonbitlang$core$array$$heap_sort_by$31$(arr, cmp) {
-  const len = moonbitlang$core$array$$ArrayView$length$31$(arr);
-  let _tmp = (len / 2 | 0) - 1 | 0;
+function moonbitlang$core$array$$sift_down_by$33$(arr, index, cmp) {
+  let index$2 = index;
+  const len = moonbitlang$core$array$$ArrayView$length$33$(arr);
+  let child = (Math.imul(index$2, 2) | 0) + 1 | 0;
   while (true) {
-    const i = _tmp;
-    if (i >= 0) {
-      moonbitlang$core$array$$sift_down_by$31$(arr, i, cmp);
-      _tmp = i - 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  let _tmp$2 = len - 1 | 0;
-  while (true) {
-    const i = _tmp$2;
-    if (i > 0) {
-      moonbitlang$core$array$$ArrayView$swap$31$(arr, 0, i);
-      moonbitlang$core$array$$sift_down_by$31$(moonbitlang$core$array$$ArrayView$op_as_view$31$(arr, 0, i), 0, cmp);
-      _tmp$2 = i - 1 | 0;
+    if (child < len) {
+      if ((child + 1 | 0) < len && cmp(moonbitlang$core$array$$ArrayView$op_get$33$(arr, child), moonbitlang$core$array$$ArrayView$op_get$33$(arr, child + 1 | 0)) < 0) {
+        child = child + 1 | 0;
+      }
+      if (cmp(moonbitlang$core$array$$ArrayView$op_get$33$(arr, index$2), moonbitlang$core$array$$ArrayView$op_get$33$(arr, child)) >= 0) {
+        return undefined;
+      }
+      moonbitlang$core$array$$ArrayView$swap$33$(arr, index$2, child);
+      index$2 = child;
+      child = (Math.imul(index$2, 2) | 0) + 1 | 0;
       continue;
     } else {
       return;
@@ -2771,30 +2643,31 @@ function moonbitlang$core$array$$heap_sort_by$32$(arr, cmp) {
     }
   }
 }
-function moonbitlang$core$array$$partition_by$31$(arr, cmp, pivot_index) {
-  moonbitlang$core$array$$ArrayView$swap$31$(arr, pivot_index, moonbitlang$core$array$$ArrayView$length$31$(arr) - 1 | 0);
-  const pivot = moonbitlang$core$array$$ArrayView$op_get$31$(arr, moonbitlang$core$array$$ArrayView$length$31$(arr) - 1 | 0);
-  let i = 0;
-  let partitioned = true;
-  let _tmp = 0;
+function moonbitlang$core$array$$heap_sort_by$33$(arr, cmp) {
+  const len = moonbitlang$core$array$$ArrayView$length$33$(arr);
+  let _tmp = (len / 2 | 0) - 1 | 0;
   while (true) {
-    const j = _tmp;
-    if (j < (moonbitlang$core$array$$ArrayView$length$31$(arr) - 1 | 0)) {
-      if (cmp(moonbitlang$core$array$$ArrayView$op_get$31$(arr, j), pivot) < 0) {
-        if (i !== j) {
-          moonbitlang$core$array$$ArrayView$swap$31$(arr, i, j);
-          partitioned = false;
-        }
-        i = i + 1 | 0;
-      }
-      _tmp = j + 1 | 0;
+    const i = _tmp;
+    if (i >= 0) {
+      moonbitlang$core$array$$sift_down_by$33$(arr, i, cmp);
+      _tmp = i - 1 | 0;
       continue;
     } else {
       break;
     }
   }
-  moonbitlang$core$array$$ArrayView$swap$31$(arr, i, moonbitlang$core$array$$ArrayView$length$31$(arr) - 1 | 0);
-  return { _0: i, _1: partitioned };
+  let _tmp$2 = len - 1 | 0;
+  while (true) {
+    const i = _tmp$2;
+    if (i > 0) {
+      moonbitlang$core$array$$ArrayView$swap$33$(arr, 0, i);
+      moonbitlang$core$array$$sift_down_by$33$(moonbitlang$core$array$$ArrayView$op_as_view$33$(arr, 0, i), 0, cmp);
+      _tmp$2 = i - 1 | 0;
+      continue;
+    } else {
+      return;
+    }
+  }
 }
 function moonbitlang$core$array$$partition_by$32$(arr, cmp, pivot_index) {
   moonbitlang$core$array$$ArrayView$swap$32$(arr, pivot_index, moonbitlang$core$array$$ArrayView$length$32$(arr) - 1 | 0);
@@ -2821,38 +2694,30 @@ function moonbitlang$core$array$$partition_by$32$(arr, cmp, pivot_index) {
   moonbitlang$core$array$$ArrayView$swap$32$(arr, i, moonbitlang$core$array$$ArrayView$length$32$(arr) - 1 | 0);
   return { _0: i, _1: partitioned };
 }
-function moonbitlang$core$array$$try_bubble_sort_by$31$(arr, cmp) {
-  let tries = 0;
-  let _tmp = 1;
+function moonbitlang$core$array$$partition_by$33$(arr, cmp, pivot_index) {
+  moonbitlang$core$array$$ArrayView$swap$33$(arr, pivot_index, moonbitlang$core$array$$ArrayView$length$33$(arr) - 1 | 0);
+  const pivot = moonbitlang$core$array$$ArrayView$op_get$33$(arr, moonbitlang$core$array$$ArrayView$length$33$(arr) - 1 | 0);
+  let i = 0;
+  let partitioned = true;
+  let _tmp = 0;
   while (true) {
-    const i = _tmp;
-    if (i < moonbitlang$core$array$$ArrayView$length$31$(arr)) {
-      let sorted = true;
-      let _tmp$2 = i;
-      while (true) {
-        const j = _tmp$2;
-        if (j > 0 && cmp(moonbitlang$core$array$$ArrayView$op_get$31$(arr, j - 1 | 0), moonbitlang$core$array$$ArrayView$op_get$31$(arr, j)) > 0) {
-          sorted = false;
-          moonbitlang$core$array$$ArrayView$swap$31$(arr, j, j - 1 | 0);
-          _tmp$2 = j - 1 | 0;
-          continue;
-        } else {
-          break;
+    const j = _tmp;
+    if (j < (moonbitlang$core$array$$ArrayView$length$33$(arr) - 1 | 0)) {
+      if (cmp(moonbitlang$core$array$$ArrayView$op_get$33$(arr, j), pivot) < 0) {
+        if (i !== j) {
+          moonbitlang$core$array$$ArrayView$swap$33$(arr, i, j);
+          partitioned = false;
         }
+        i = i + 1 | 0;
       }
-      if (!sorted) {
-        tries = tries + 1 | 0;
-        if (tries > 8) {
-          return false;
-        }
-      }
-      _tmp = i + 1 | 0;
+      _tmp = j + 1 | 0;
       continue;
     } else {
       break;
     }
   }
-  return true;
+  moonbitlang$core$array$$ArrayView$swap$33$(arr, i, moonbitlang$core$array$$ArrayView$length$33$(arr) - 1 | 0);
+  return { _0: i, _1: partitioned };
 }
 function moonbitlang$core$array$$try_bubble_sort_by$32$(arr, cmp) {
   let tries = 0;
@@ -2887,71 +2752,38 @@ function moonbitlang$core$array$$try_bubble_sort_by$32$(arr, cmp) {
   }
   return true;
 }
-function moonbitlang$core$array$$quick_sort_by$31$(arr, cmp, pred, limit) {
-  let limit$2 = limit;
-  let arr$2 = arr;
-  let pred$2 = pred;
-  let was_partitioned = true;
-  let balanced = true;
+function moonbitlang$core$array$$try_bubble_sort_by$33$(arr, cmp) {
+  let tries = 0;
+  let _tmp = 1;
   while (true) {
-    const len = moonbitlang$core$array$$ArrayView$length$31$(arr$2);
-    if (len <= 16) {
-      if (len >= 2) {
-        moonbitlang$core$array$$bubble_sort_by$31$(arr$2, cmp);
-      }
-      return undefined;
-    }
-    if (limit$2 === 0) {
-      moonbitlang$core$array$$heap_sort_by$31$(arr$2, cmp);
-      return undefined;
-    }
-    const _bind = moonbitlang$core$array$$choose_pivot_by$31$(arr$2, cmp);
-    const _x = _bind._0;
-    const _x$2 = _bind._1;
-    if (was_partitioned && (balanced && _x$2)) {
-      if (moonbitlang$core$array$$try_bubble_sort_by$31$(arr$2, cmp)) {
-        return undefined;
-      }
-    }
-    const _bind$2 = moonbitlang$core$array$$partition_by$31$(arr$2, cmp, _x);
-    const _x$3 = _bind$2._0;
-    const _x$4 = _bind$2._1;
-    was_partitioned = _x$4;
-    balanced = moonbitlang$core$array$$minimum(_x$3, len - _x$3 | 0) >= (len / 8 | 0);
-    if (!balanced) {
-      limit$2 = limit$2 - 1 | 0;
-    }
-    const _bind$3 = pred$2;
-    if (_bind$3 === undefined) {
-    } else {
-      const _Some = _bind$3;
-      const _x$5 = _Some;
-      if (cmp(_x$5, moonbitlang$core$array$$ArrayView$op_get$31$(arr$2, _x$3)) === 0) {
-        let i = _x$3;
-        while (true) {
-          if (i < len && cmp(_x$5, moonbitlang$core$array$$ArrayView$op_get$31$(arr$2, i)) === 0) {
-            i = i + 1 | 0;
-            continue;
-          } else {
-            break;
-          }
+    const i = _tmp;
+    if (i < moonbitlang$core$array$$ArrayView$length$33$(arr)) {
+      let sorted = true;
+      let _tmp$2 = i;
+      while (true) {
+        const j = _tmp$2;
+        if (j > 0 && cmp(moonbitlang$core$array$$ArrayView$op_get$33$(arr, j - 1 | 0), moonbitlang$core$array$$ArrayView$op_get$33$(arr, j)) > 0) {
+          sorted = false;
+          moonbitlang$core$array$$ArrayView$swap$33$(arr, j, j - 1 | 0);
+          _tmp$2 = j - 1 | 0;
+          continue;
+        } else {
+          break;
         }
-        arr$2 = moonbitlang$core$array$$ArrayView$op_as_view$31$(arr$2, i, len);
-        continue;
       }
-    }
-    const left = moonbitlang$core$array$$ArrayView$op_as_view$31$(arr$2, 0, _x$3);
-    const right = moonbitlang$core$array$$ArrayView$op_as_view$31$(arr$2, _x$3 + 1 | 0, len);
-    if (moonbitlang$core$array$$ArrayView$length$31$(left) < moonbitlang$core$array$$ArrayView$length$31$(right)) {
-      moonbitlang$core$array$$quick_sort_by$31$(left, cmp, pred$2, limit$2);
-      pred$2 = moonbitlang$core$array$$ArrayView$op_get$31$(arr$2, _x$3);
-      arr$2 = right;
+      if (!sorted) {
+        tries = tries + 1 | 0;
+        if (tries > 8) {
+          return false;
+        }
+      }
+      _tmp = i + 1 | 0;
+      continue;
     } else {
-      moonbitlang$core$array$$quick_sort_by$31$(right, cmp, moonbitlang$core$array$$ArrayView$op_get$31$(arr$2, _x$3), limit$2);
-      arr$2 = left;
+      break;
     }
-    continue;
   }
+  return true;
 }
 function moonbitlang$core$array$$quick_sort_by$32$(arr, cmp, pred, limit) {
   let limit$2 = limit;
@@ -3019,11 +2851,77 @@ function moonbitlang$core$array$$quick_sort_by$32$(arr, cmp, pred, limit) {
     continue;
   }
 }
-function moonbitlang$core$array$$Array$sort_by_key$35$(self, map) {
-  moonbitlang$core$array$$quick_sort_by$31$({ buf: self, start: 0, len: self.length }, (a, b) => moonbitlang$core$builtin$$Compare$compare$36$(map(a), map(b)), undefined, moonbitlang$core$array$$get_limit(self.length));
+function moonbitlang$core$array$$quick_sort_by$33$(arr, cmp, pred, limit) {
+  let limit$2 = limit;
+  let arr$2 = arr;
+  let pred$2 = pred;
+  let was_partitioned = true;
+  let balanced = true;
+  while (true) {
+    const len = moonbitlang$core$array$$ArrayView$length$33$(arr$2);
+    if (len <= 16) {
+      if (len >= 2) {
+        moonbitlang$core$array$$bubble_sort_by$33$(arr$2, cmp);
+      }
+      return undefined;
+    }
+    if (limit$2 === 0) {
+      moonbitlang$core$array$$heap_sort_by$33$(arr$2, cmp);
+      return undefined;
+    }
+    const _bind = moonbitlang$core$array$$choose_pivot_by$33$(arr$2, cmp);
+    const _x = _bind._0;
+    const _x$2 = _bind._1;
+    if (was_partitioned && (balanced && _x$2)) {
+      if (moonbitlang$core$array$$try_bubble_sort_by$33$(arr$2, cmp)) {
+        return undefined;
+      }
+    }
+    const _bind$2 = moonbitlang$core$array$$partition_by$33$(arr$2, cmp, _x);
+    const _x$3 = _bind$2._0;
+    const _x$4 = _bind$2._1;
+    was_partitioned = _x$4;
+    balanced = moonbitlang$core$array$$minimum(_x$3, len - _x$3 | 0) >= (len / 8 | 0);
+    if (!balanced) {
+      limit$2 = limit$2 - 1 | 0;
+    }
+    const _bind$3 = pred$2;
+    if (_bind$3 === undefined) {
+    } else {
+      const _Some = _bind$3;
+      const _x$5 = _Some;
+      if (cmp(_x$5, moonbitlang$core$array$$ArrayView$op_get$33$(arr$2, _x$3)) === 0) {
+        let i = _x$3;
+        while (true) {
+          if (i < len && cmp(_x$5, moonbitlang$core$array$$ArrayView$op_get$33$(arr$2, i)) === 0) {
+            i = i + 1 | 0;
+            continue;
+          } else {
+            break;
+          }
+        }
+        arr$2 = moonbitlang$core$array$$ArrayView$op_as_view$33$(arr$2, i, len);
+        continue;
+      }
+    }
+    const left = moonbitlang$core$array$$ArrayView$op_as_view$33$(arr$2, 0, _x$3);
+    const right = moonbitlang$core$array$$ArrayView$op_as_view$33$(arr$2, _x$3 + 1 | 0, len);
+    if (moonbitlang$core$array$$ArrayView$length$33$(left) < moonbitlang$core$array$$ArrayView$length$33$(right)) {
+      moonbitlang$core$array$$quick_sort_by$33$(left, cmp, pred$2, limit$2);
+      pred$2 = moonbitlang$core$array$$ArrayView$op_get$33$(arr$2, _x$3);
+      arr$2 = right;
+    } else {
+      moonbitlang$core$array$$quick_sort_by$33$(right, cmp, moonbitlang$core$array$$ArrayView$op_get$33$(arr$2, _x$3), limit$2);
+      arr$2 = left;
+    }
+    continue;
+  }
 }
-function moonbitlang$core$array$$Array$sort_by_key$37$(self, map) {
-  moonbitlang$core$array$$quick_sort_by$32$({ buf: self, start: 0, len: self.length }, (a, b) => $compare_int(map(a), map(b)), undefined, moonbitlang$core$array$$get_limit(self.length));
+function moonbitlang$core$array$$Array$sort_by_key$36$(self, map) {
+  moonbitlang$core$array$$quick_sort_by$32$({ buf: self, start: 0, len: self.length }, (a, b) => moonbitlang$core$builtin$$Compare$compare$37$(map(a), map(b)), undefined, moonbitlang$core$array$$get_limit(self.length));
+}
+function moonbitlang$core$array$$Array$sort_by_key$38$(self, map) {
+  moonbitlang$core$array$$quick_sort_by$33$({ buf: self, start: 0, len: self.length }, (a, b) => $compare_int(map(a), map(b)), undefined, moonbitlang$core$array$$get_limit(self.length));
 }
 function moonbitlang$core$array$$Array$push_iter$10$(self, iter) {
   iter((x) => {
@@ -3031,10 +2929,10 @@ function moonbitlang$core$array$$Array$push_iter$10$(self, iter) {
     return 1;
   });
 }
-function moonbitlang$core$immut$sorted_set$$new$38$() {
+function moonbitlang$core$immut$sorted_set$$new$39$() {
   return $64$moonbitlang$47$core$47$immut$47$sorted_set$46$T$Empty$4$;
 }
-function moonbitlang$core$immut$sorted_set$$T$size$38$(self) {
+function moonbitlang$core$immut$sorted_set$$T$size$39$(self) {
   if (self.$tag === 0) {
     return 0;
   } else {
@@ -3043,67 +2941,67 @@ function moonbitlang$core$immut$sorted_set$$T$size$38$(self) {
     return _x;
   }
 }
-function moonbitlang$core$immut$sorted_set$$create$38$(left, value, right) {
-  return new $64$moonbitlang$47$core$47$immut$47$sorted_set$46$T$Node$4$(left, right, (moonbitlang$core$immut$sorted_set$$T$size$38$(left) + moonbitlang$core$immut$sorted_set$$T$size$38$(right) | 0) + 1 | 0, value);
+function moonbitlang$core$immut$sorted_set$$create$39$(left, value, right) {
+  return new $64$moonbitlang$47$core$47$immut$47$sorted_set$46$T$Node$4$(left, right, (moonbitlang$core$immut$sorted_set$$T$size$39$(left) + moonbitlang$core$immut$sorted_set$$T$size$39$(right) | 0) + 1 | 0, value);
 }
-function moonbitlang$core$immut$sorted_set$$balance$38$(left, value, right) {
-  const left_size = moonbitlang$core$immut$sorted_set$$T$size$38$(left);
-  const right_size = moonbitlang$core$immut$sorted_set$$T$size$38$(right);
+function moonbitlang$core$immut$sorted_set$$balance$39$(left, value, right) {
+  const left_size = moonbitlang$core$immut$sorted_set$$T$size$39$(left);
+  const right_size = moonbitlang$core$immut$sorted_set$$T$size$39$(right);
   if ((left_size + right_size | 0) < 2) {
-    return moonbitlang$core$immut$sorted_set$$create$38$(left, value, right);
+    return moonbitlang$core$immut$sorted_set$$create$39$(left, value, right);
   } else {
     if (left_size > (Math.imul(right_size, 5) | 0)) {
       if (left.$tag === 0) {
-        return moonbitlang$core$builtin$$abort$39$("balance: left is empty.");
+        return moonbitlang$core$builtin$$abort$40$("balance: left is empty.");
       } else {
         const _Node = left;
         const _x = _Node._0;
         const _x$2 = _Node._3;
         const _x$3 = _Node._1;
-        if (moonbitlang$core$immut$sorted_set$$T$size$38$(_x) >= moonbitlang$core$immut$sorted_set$$T$size$38$(_x$3)) {
-          return moonbitlang$core$immut$sorted_set$$create$38$(_x, _x$2, moonbitlang$core$immut$sorted_set$$create$38$(_x$3, value, right));
+        if (moonbitlang$core$immut$sorted_set$$T$size$39$(_x) >= moonbitlang$core$immut$sorted_set$$T$size$39$(_x$3)) {
+          return moonbitlang$core$immut$sorted_set$$create$39$(_x, _x$2, moonbitlang$core$immut$sorted_set$$create$39$(_x$3, value, right));
         } else {
           if (_x$3.$tag === 0) {
-            return moonbitlang$core$builtin$$abort$39$("balance: right left.right is empty.");
+            return moonbitlang$core$builtin$$abort$40$("balance: right left.right is empty.");
           } else {
             const _Node$2 = _x$3;
             const _x$4 = _Node$2._0;
             const _x$5 = _Node$2._3;
             const _x$6 = _Node$2._1;
-            return moonbitlang$core$immut$sorted_set$$create$38$(moonbitlang$core$immut$sorted_set$$create$38$(_x, _x$2, _x$4), _x$5, moonbitlang$core$immut$sorted_set$$create$38$(_x$6, value, right));
+            return moonbitlang$core$immut$sorted_set$$create$39$(moonbitlang$core$immut$sorted_set$$create$39$(_x, _x$2, _x$4), _x$5, moonbitlang$core$immut$sorted_set$$create$39$(_x$6, value, right));
           }
         }
       }
     } else {
       if (right_size > (Math.imul(left_size, 5) | 0)) {
         if (right.$tag === 0) {
-          return moonbitlang$core$builtin$$abort$39$("balance: right is empty");
+          return moonbitlang$core$builtin$$abort$40$("balance: right is empty");
         } else {
           const _Node = right;
           const _x = _Node._0;
           const _x$2 = _Node._3;
           const _x$3 = _Node._1;
-          if (moonbitlang$core$immut$sorted_set$$T$size$38$(_x$3) >= moonbitlang$core$immut$sorted_set$$T$size$38$(_x)) {
-            return moonbitlang$core$immut$sorted_set$$create$38$(moonbitlang$core$immut$sorted_set$$create$38$(left, value, _x), _x$2, _x$3);
+          if (moonbitlang$core$immut$sorted_set$$T$size$39$(_x$3) >= moonbitlang$core$immut$sorted_set$$T$size$39$(_x)) {
+            return moonbitlang$core$immut$sorted_set$$create$39$(moonbitlang$core$immut$sorted_set$$create$39$(left, value, _x), _x$2, _x$3);
           } else {
             if (_x.$tag === 0) {
-              return moonbitlang$core$builtin$$abort$39$("balance: right.left is empty");
+              return moonbitlang$core$builtin$$abort$40$("balance: right.left is empty");
             } else {
               const _Node$2 = _x;
               const _x$4 = _Node$2._0;
               const _x$5 = _Node$2._3;
               const _x$6 = _Node$2._1;
-              return moonbitlang$core$immut$sorted_set$$create$38$(moonbitlang$core$immut$sorted_set$$create$38$(left, value, _x$4), _x$5, moonbitlang$core$immut$sorted_set$$create$38$(_x$6, _x$2, _x$3));
+              return moonbitlang$core$immut$sorted_set$$create$39$(moonbitlang$core$immut$sorted_set$$create$39$(left, value, _x$4), _x$5, moonbitlang$core$immut$sorted_set$$create$39$(_x$6, _x$2, _x$3));
             }
           }
         }
       } else {
-        return moonbitlang$core$immut$sorted_set$$create$38$(left, value, right);
+        return moonbitlang$core$immut$sorted_set$$create$39$(left, value, right);
       }
     }
   }
 }
-function moonbitlang$core$immut$sorted_set$$T$add$38$(self, value) {
+function moonbitlang$core$immut$sorted_set$$T$add$39$(self, value) {
   if (self.$tag === 0) {
     return new $64$moonbitlang$47$core$47$immut$47$sorted_set$46$T$Node$4$($64$moonbitlang$47$core$47$immut$47$sorted_set$46$T$Empty$4$, $64$moonbitlang$47$core$47$immut$47$sorted_set$46$T$Empty$4$, 1, value);
   } else {
@@ -3111,22 +3009,22 @@ function moonbitlang$core$immut$sorted_set$$T$add$38$(self, value) {
     const _x = _Node._0;
     const _x$2 = _Node._1;
     const _x$3 = _Node._3;
-    const compare_result = moonbitlang$core$builtin$$Compare$compare$38$(value, _x$3);
+    const compare_result = moonbitlang$core$builtin$$Compare$compare$39$(value, _x$3);
     if (compare_result === 0) {
       return self;
     } else {
       if (compare_result < 0) {
-        const ll = moonbitlang$core$immut$sorted_set$$T$add$38$(_x, value);
-        return _x === ll ? self : moonbitlang$core$immut$sorted_set$$balance$38$(ll, _x$3, _x$2);
+        const ll = moonbitlang$core$immut$sorted_set$$T$add$39$(_x, value);
+        return _x === ll ? self : moonbitlang$core$immut$sorted_set$$balance$39$(ll, _x$3, _x$2);
       } else {
-        const rr = moonbitlang$core$immut$sorted_set$$T$add$38$(_x$2, value);
-        return _x$2 === rr ? self : moonbitlang$core$immut$sorted_set$$balance$38$(_x, _x$3, rr);
+        const rr = moonbitlang$core$immut$sorted_set$$T$add$39$(_x$2, value);
+        return _x$2 === rr ? self : moonbitlang$core$immut$sorted_set$$balance$39$(_x, _x$3, rr);
       }
     }
   }
 }
-function moonbitlang$core$immut$sorted_set$$T$iter$38$(self) {
-  return moonbitlang$core$builtin$$Iter$new$38$((yield_) => {
+function moonbitlang$core$immut$sorted_set$$T$iter$39$(self) {
+  return moonbitlang$core$builtin$$Iter$new$39$((yield_) => {
     if (self.$tag === 0) {
       return 1;
     } else {
@@ -3134,7 +3032,7 @@ function moonbitlang$core$immut$sorted_set$$T$iter$38$(self) {
       const _x = _Node._0;
       const _x$2 = _Node._1;
       const _x$3 = _Node._3;
-      return moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter$run$38$(moonbitlang$core$immut$sorted_set$$T$iter$38$(_x), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x$3), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter$run$38$(moonbitlang$core$immut$sorted_set$$T$iter$38$(_x$2), yield_), 0) ? 0 : 1;
+      return moonbitlang$core$builtin$$Eq$op_equal$13$(moonbitlang$core$builtin$$Iter$run$39$(moonbitlang$core$immut$sorted_set$$T$iter$39$(_x), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(_x$3), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$13$(moonbitlang$core$builtin$$Iter$run$39$(moonbitlang$core$immut$sorted_set$$T$iter$39$(_x$2), yield_), 0) ? 0 : 1;
     }
   });
 }
@@ -3147,28 +3045,28 @@ function moonbitlang$core$immut$internal$sparse_array$$Bitset$index_of(self, idx
 function moonbitlang$core$immut$internal$sparse_array$$Bitset$add(self, idx) {
   return self | 1 << idx;
 }
-function moonbitlang$core$immut$internal$sparse_array$$singleton$33$(idx, value) {
+function moonbitlang$core$immut$internal$sparse_array$$singleton$34$(idx, value) {
   return { elem_info: moonbitlang$core$immut$internal$sparse_array$$Bitset$add(moonbitlang$core$immut$internal$sparse_array$$empty_bitset, idx), data: [value] };
 }
-function moonbitlang$core$immut$internal$sparse_array$$SparseArray$op_get$33$(self, idx) {
+function moonbitlang$core$immut$internal$sparse_array$$SparseArray$op_get$34$(self, idx) {
   return moonbitlang$core$immut$internal$sparse_array$$Bitset$has(self.elem_info, idx) ? self.data[moonbitlang$core$immut$internal$sparse_array$$Bitset$index_of(self.elem_info, idx)] : undefined;
 }
-function moonbitlang$core$immut$internal$sparse_array$$SparseArray$add$33$(self, idx, value) {
+function moonbitlang$core$immut$internal$sparse_array$$SparseArray$add$34$(self, idx, value) {
   const old_data = self.data;
   const old_len = old_data.length;
   const new_len = old_len + 1 | 0;
   const pos_of_new_item = moonbitlang$core$immut$internal$sparse_array$$Bitset$index_of(self.elem_info, idx);
   const new_data = $make_array_len_and_init(new_len, value);
-  moonbitlang$core$array$$FixedArray$blit_to$33$(old_data, new_data, pos_of_new_item, moonbitlang$core$array$$FixedArray$blit_to$46$src_offset$46$default$33$(), moonbitlang$core$array$$FixedArray$blit_to$46$dst_offset$46$default$33$());
-  moonbitlang$core$array$$FixedArray$blit_to$33$(old_data, new_data, old_len - pos_of_new_item | 0, pos_of_new_item, pos_of_new_item + 1 | 0);
+  moonbitlang$core$array$$FixedArray$blit_to$34$(old_data, new_data, pos_of_new_item, moonbitlang$core$array$$FixedArray$blit_to$46$src_offset$46$default$34$(), moonbitlang$core$array$$FixedArray$blit_to$46$dst_offset$46$default$34$());
+  moonbitlang$core$array$$FixedArray$blit_to$34$(old_data, new_data, old_len - pos_of_new_item | 0, pos_of_new_item, pos_of_new_item + 1 | 0);
   return { elem_info: moonbitlang$core$immut$internal$sparse_array$$Bitset$add(self.elem_info, idx), data: new_data };
 }
-function moonbitlang$core$immut$internal$sparse_array$$SparseArray$replace$33$(self, idx, value) {
-  const new_data = moonbitlang$core$array$$FixedArray$copy$33$(self.data);
+function moonbitlang$core$immut$internal$sparse_array$$SparseArray$replace$34$(self, idx, value) {
+  const new_data = moonbitlang$core$array$$FixedArray$copy$34$(self.data);
   new_data[moonbitlang$core$immut$internal$sparse_array$$Bitset$index_of(self.elem_info, idx)] = value;
   return { elem_info: self.elem_info, data: new_data };
 }
-function moonbitlang$core$immut$sorted_map$$T$size$40$(self) {
+function moonbitlang$core$immut$sorted_map$$T$size$41$(self) {
   if (self.$tag === 0) {
     return 0;
   } else {
@@ -3176,23 +3074,23 @@ function moonbitlang$core$immut$sorted_map$$T$size$40$(self) {
     return _Tree._2;
   }
 }
-function moonbitlang$core$immut$sorted_map$$make_tree$40$(key, value, l, r) {
-  const size = (moonbitlang$core$immut$sorted_map$$T$size$40$(l) + moonbitlang$core$immut$sorted_map$$T$size$40$(r) | 0) + 1 | 0;
+function moonbitlang$core$immut$sorted_map$$make_tree$41$(key, value, l, r) {
+  const size = (moonbitlang$core$immut$sorted_map$$T$size$41$(l) + moonbitlang$core$immut$sorted_map$$T$size$41$(r) | 0) + 1 | 0;
   return new $64$moonbitlang$47$core$47$immut$47$sorted_map$46$T$Tree$5$(key, value, size, l, r);
 }
-function moonbitlang$core$immut$sorted_map$$balance$40$(key, value, l, r) {
-  const ln = moonbitlang$core$immut$sorted_map$$T$size$40$(l);
-  const rn = moonbitlang$core$immut$sorted_map$$T$size$40$(r);
+function moonbitlang$core$immut$sorted_map$$balance$41$(key, value, l, r) {
+  const ln = moonbitlang$core$immut$sorted_map$$T$size$41$(l);
+  const rn = moonbitlang$core$immut$sorted_map$$T$size$41$(r);
   if ((ln + rn | 0) < 2) {
-    return moonbitlang$core$immut$sorted_map$$make_tree$40$(key, value, l, r);
+    return moonbitlang$core$immut$sorted_map$$make_tree$41$(key, value, l, r);
   } else {
     if (rn > (Math.imul(5, ln) | 0)) {
       if (r.$tag === 1) {
         const _Tree = r;
         const _x = _Tree._3;
         const _x$2 = _Tree._4;
-        const rln = moonbitlang$core$immut$sorted_map$$T$size$40$(_x);
-        const rrn = moonbitlang$core$immut$sorted_map$$T$size$40$(_x$2);
+        const rln = moonbitlang$core$immut$sorted_map$$T$size$41$(_x);
+        const rrn = moonbitlang$core$immut$sorted_map$$T$size$41$(_x$2);
         if (rln < rrn) {
           if (r.$tag === 1) {
             const _Tree$2 = r;
@@ -3200,7 +3098,7 @@ function moonbitlang$core$immut$sorted_map$$balance$40$(key, value, l, r) {
             const _x$4 = _Tree$2._1;
             const _x$5 = _Tree$2._3;
             const _x$6 = _Tree$2._4;
-            return moonbitlang$core$immut$sorted_map$$make_tree$40$(_x$3, _x$4, moonbitlang$core$immut$sorted_map$$make_tree$40$(key, value, l, _x$5), _x$6);
+            return moonbitlang$core$immut$sorted_map$$make_tree$41$(_x$3, _x$4, moonbitlang$core$immut$sorted_map$$make_tree$41$(key, value, l, _x$5), _x$6);
           } else {
             return $panic();
           }
@@ -3217,7 +3115,7 @@ function moonbitlang$core$immut$sorted_map$$balance$40$(key, value, l, r) {
               const _x$8 = _Tree$3._3;
               const _x$9 = _Tree$3._4;
               const _x$10 = _Tree$2._4;
-              return moonbitlang$core$immut$sorted_map$$make_tree$40$(_x$6, _x$7, moonbitlang$core$immut$sorted_map$$make_tree$40$(key, value, l, _x$8), moonbitlang$core$immut$sorted_map$$make_tree$40$(_x$3, _x$4, _x$9, _x$10));
+              return moonbitlang$core$immut$sorted_map$$make_tree$41$(_x$6, _x$7, moonbitlang$core$immut$sorted_map$$make_tree$41$(key, value, l, _x$8), moonbitlang$core$immut$sorted_map$$make_tree$41$(_x$3, _x$4, _x$9, _x$10));
             } else {
               return $panic();
             }
@@ -3234,8 +3132,8 @@ function moonbitlang$core$immut$sorted_map$$balance$40$(key, value, l, r) {
           const _Tree = l;
           const _x = _Tree._3;
           const _x$2 = _Tree._4;
-          const lln = moonbitlang$core$immut$sorted_map$$T$size$40$(_x);
-          const lrn = moonbitlang$core$immut$sorted_map$$T$size$40$(_x$2);
+          const lln = moonbitlang$core$immut$sorted_map$$T$size$41$(_x);
+          const lrn = moonbitlang$core$immut$sorted_map$$T$size$41$(_x$2);
           if (lrn < lln) {
             if (l.$tag === 1) {
               const _Tree$2 = l;
@@ -3243,7 +3141,7 @@ function moonbitlang$core$immut$sorted_map$$balance$40$(key, value, l, r) {
               const _x$4 = _Tree$2._1;
               const _x$5 = _Tree$2._3;
               const _x$6 = _Tree$2._4;
-              return moonbitlang$core$immut$sorted_map$$make_tree$40$(_x$3, _x$4, _x$5, moonbitlang$core$immut$sorted_map$$make_tree$40$(key, value, _x$6, r));
+              return moonbitlang$core$immut$sorted_map$$make_tree$41$(_x$3, _x$4, _x$5, moonbitlang$core$immut$sorted_map$$make_tree$41$(key, value, _x$6, r));
             } else {
               return $panic();
             }
@@ -3260,7 +3158,7 @@ function moonbitlang$core$immut$sorted_map$$balance$40$(key, value, l, r) {
                 const _x$8 = _Tree$3._1;
                 const _x$9 = _Tree$3._3;
                 const _x$10 = _Tree$3._4;
-                return moonbitlang$core$immut$sorted_map$$make_tree$40$(_x$7, _x$8, moonbitlang$core$immut$sorted_map$$make_tree$40$(_x$3, _x$4, _x$5, _x$9), moonbitlang$core$immut$sorted_map$$make_tree$40$(key, value, _x$10, r));
+                return moonbitlang$core$immut$sorted_map$$make_tree$41$(_x$7, _x$8, moonbitlang$core$immut$sorted_map$$make_tree$41$(_x$3, _x$4, _x$5, _x$9), moonbitlang$core$immut$sorted_map$$make_tree$41$(key, value, _x$10, r));
               } else {
                 return $panic();
               }
@@ -3272,17 +3170,17 @@ function moonbitlang$core$immut$sorted_map$$balance$40$(key, value, l, r) {
           return $panic();
         }
       } else {
-        return moonbitlang$core$immut$sorted_map$$make_tree$40$(key, value, l, r);
+        return moonbitlang$core$immut$sorted_map$$make_tree$41$(key, value, l, r);
       }
     }
   }
 }
-function moonbitlang$core$immut$sorted_map$$singleton$40$(key, value) {
+function moonbitlang$core$immut$sorted_map$$singleton$41$(key, value) {
   return new $64$moonbitlang$47$core$47$immut$47$sorted_map$46$T$Tree$5$(key, value, 1, $64$moonbitlang$47$core$47$immut$47$sorted_map$46$T$Empty$5$, $64$moonbitlang$47$core$47$immut$47$sorted_map$46$T$Empty$5$);
 }
-function moonbitlang$core$immut$sorted_map$$T$add$40$(self, key, value) {
+function moonbitlang$core$immut$sorted_map$$T$add$41$(self, key, value) {
   if (self.$tag === 0) {
-    return moonbitlang$core$immut$sorted_map$$singleton$40$(key, value);
+    return moonbitlang$core$immut$sorted_map$$singleton$41$(key, value);
   } else {
     const _Tree = self;
     const _x = _Tree._0;
@@ -3290,13 +3188,13 @@ function moonbitlang$core$immut$sorted_map$$T$add$40$(self, key, value) {
     const _x$3 = _Tree._3;
     const _x$4 = _Tree._4;
     const c = $compare_int(key, _x);
-    return c === 0 ? moonbitlang$core$immut$sorted_map$$make_tree$40$(_x, value, _x$3, _x$4) : c < 0 ? moonbitlang$core$immut$sorted_map$$balance$40$(_x, _x$2, moonbitlang$core$immut$sorted_map$$T$add$40$(_x$3, key, value), _x$4) : moonbitlang$core$immut$sorted_map$$balance$40$(_x, _x$2, _x$3, moonbitlang$core$immut$sorted_map$$T$add$40$(_x$4, key, value));
+    return c === 0 ? moonbitlang$core$immut$sorted_map$$make_tree$41$(_x, value, _x$3, _x$4) : c < 0 ? moonbitlang$core$immut$sorted_map$$balance$41$(_x, _x$2, moonbitlang$core$immut$sorted_map$$T$add$41$(_x$3, key, value), _x$4) : moonbitlang$core$immut$sorted_map$$balance$41$(_x, _x$2, _x$3, moonbitlang$core$immut$sorted_map$$T$add$41$(_x$4, key, value));
   }
 }
-function moonbitlang$core$immut$sorted_map$$new$40$() {
+function moonbitlang$core$immut$sorted_map$$new$41$() {
   return $64$moonbitlang$47$core$47$immut$47$sorted_map$46$T$Empty$5$;
 }
-function moonbitlang$core$immut$sorted_map$$T$lookup$40$(self, key) {
+function moonbitlang$core$immut$sorted_map$$T$lookup$41$(self, key) {
   let _tmp = self;
   while (true) {
     const _param = _tmp;
@@ -3323,10 +3221,10 @@ function moonbitlang$core$immut$sorted_map$$T$lookup$40$(self, key) {
     }
   }
 }
-function moonbitlang$core$immut$sorted_map$$T$op_get$40$(self, key) {
-  return moonbitlang$core$immut$sorted_map$$T$lookup$40$(self, key);
+function moonbitlang$core$immut$sorted_map$$T$op_get$41$(self, key) {
+  return moonbitlang$core$immut$sorted_map$$T$lookup$41$(self, key);
 }
-function moonbitlang$core$builtin$$Eq$op_equal$41$(_x_371, _x_372) {
+function moonbitlang$core$builtin$$Eq$op_equal$42$(_x_371, _x_372) {
   let _tmp = _x_371;
   let _tmp$2 = _x_372;
   while (true) {
@@ -3346,7 +3244,7 @@ function moonbitlang$core$builtin$$Eq$op_equal$41$(_x_371, _x_372) {
         const _Cons$2 = _x_372$2;
         const _x$3 = _Cons$2._0;
         const _x$4 = _Cons$2._1;
-        if (moonbitlang$core$builtin$$Eq$op_equal$42$(_x, _x$3)) {
+        if (moonbitlang$core$builtin$$Eq$op_equal$43$(_x, _x$3)) {
           _tmp = _x$2;
           _tmp$2 = _x$4;
           continue;
@@ -3359,6 +3257,26 @@ function moonbitlang$core$builtin$$Eq$op_equal$41$(_x_371, _x_372) {
     }
   }
 }
+function moonbitlang$core$immut$list$$T$iter$44$(self) {
+  return moonbitlang$core$builtin$$Iter$new$44$((yield_) => {
+    let _tmp = self;
+    while (true) {
+      const _param = _tmp;
+      if (_param.$tag === 0) {
+        return 1;
+      } else {
+        const _Cons = _param;
+        const _x = _Cons._0;
+        const _x$2 = _Cons._1;
+        if (moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(_x), 0)) {
+          return 0;
+        }
+        _tmp = _x$2;
+        continue;
+      }
+    }
+  });
+}
 function moonbitlang$core$immut$list$$T$iter$43$(self) {
   return moonbitlang$core$builtin$$Iter$new$43$((yield_) => {
     let _tmp = self;
@@ -3370,7 +3288,7 @@ function moonbitlang$core$immut$list$$T$iter$43$(self) {
         const _Cons = _param;
         const _x = _Cons._0;
         const _x$2 = _Cons._1;
-        if (moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x), 0)) {
+        if (moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(_x), 0)) {
           return 0;
         }
         _tmp = _x$2;
@@ -3378,51 +3296,6 @@ function moonbitlang$core$immut$list$$T$iter$43$(self) {
       }
     }
   });
-}
-function moonbitlang$core$immut$list$$T$iter$42$(self) {
-  return moonbitlang$core$builtin$$Iter$new$42$((yield_) => {
-    let _tmp = self;
-    while (true) {
-      const _param = _tmp;
-      if (_param.$tag === 0) {
-        return 1;
-      } else {
-        const _Cons = _param;
-        const _x = _Cons._0;
-        const _x$2 = _Cons._1;
-        if (moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x), 0)) {
-          return 0;
-        }
-        _tmp = _x$2;
-        continue;
-      }
-    }
-  });
-}
-function moonbitlang$core$immut$list$$T$to_array$44$(self) {
-  if (self.$tag === 0) {
-    return [];
-  } else {
-    const _Cons = self;
-    const _x = _Cons._0;
-    const _x$2 = _Cons._1;
-    const arr = [_x];
-    let _tmp = _x$2;
-    while (true) {
-      const _param = _tmp;
-      if (_param.$tag === 0) {
-        break;
-      } else {
-        const _Cons$2 = _param;
-        const _x$3 = _Cons$2._0;
-        const _x$4 = _Cons$2._1;
-        moonbitlang$core$array$$Array$push$44$(arr, _x$3);
-        _tmp = _x$4;
-        continue;
-      }
-    }
-    return arr;
-  }
 }
 function moonbitlang$core$immut$list$$T$to_array$45$(self) {
   if (self.$tag === 0) {
@@ -3499,6 +3372,31 @@ function moonbitlang$core$immut$list$$T$to_array$47$(self) {
     return arr;
   }
 }
+function moonbitlang$core$immut$list$$T$to_array$48$(self) {
+  if (self.$tag === 0) {
+    return [];
+  } else {
+    const _Cons = self;
+    const _x = _Cons._0;
+    const _x$2 = _Cons._1;
+    const arr = [_x];
+    let _tmp = _x$2;
+    while (true) {
+      const _param = _tmp;
+      if (_param.$tag === 0) {
+        break;
+      } else {
+        const _Cons$2 = _param;
+        const _x$3 = _Cons$2._0;
+        const _x$4 = _Cons$2._1;
+        moonbitlang$core$array$$Array$push$48$(arr, _x$3);
+        _tmp = _x$4;
+        continue;
+      }
+    }
+    return arr;
+  }
+}
 function moonbitlang$core$immut$list$$T$to_array$10$(self) {
   if (self.$tag === 0) {
     return [];
@@ -3524,7 +3422,7 @@ function moonbitlang$core$immut$list$$T$to_array$10$(self) {
     return arr;
   }
 }
-function moonbitlang$core$immut$list$$T$tail$48$(self) {
+function moonbitlang$core$immut$list$$T$tail$49$(self) {
   if (self.$tag === 0) {
     return $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$6$;
   } else {
@@ -3533,16 +3431,16 @@ function moonbitlang$core$immut$list$$T$tail$48$(self) {
     return _x;
   }
 }
-function moonbitlang$core$immut$list$$T$unsafe_head$48$(self) {
+function moonbitlang$core$immut$list$$T$unsafe_head$49$(self) {
   if (self.$tag === 0) {
-    return moonbitlang$core$builtin$$abort$48$("head of empty list");
+    return moonbitlang$core$builtin$$abort$49$("head of empty list");
   } else {
     const _Cons = self;
     const _x = _Cons._0;
     return _x;
   }
 }
-function moonbitlang$core$immut$list$$T$contains$42$(self, value) {
+function moonbitlang$core$immut$list$$T$contains$43$(self, value) {
   let _tmp = self;
   while (true) {
     const _param = _tmp;
@@ -3552,7 +3450,7 @@ function moonbitlang$core$immut$list$$T$contains$42$(self, value) {
       const _Cons = _param;
       const _x = _Cons._0;
       const _x$2 = _Cons._1;
-      if (moonbitlang$core$builtin$$Eq$op_equal$42$(_x, value)) {
+      if (moonbitlang$core$builtin$$Eq$op_equal$43$(_x, value)) {
         return true;
       } else {
         _tmp = _x$2;
@@ -3561,7 +3459,7 @@ function moonbitlang$core$immut$list$$T$contains$42$(self, value) {
     }
   }
 }
-function moonbitlang$core$immut$list$$T$drop$48$(self, n) {
+function moonbitlang$core$immut$list$$T$drop$49$(self, n) {
   let _param3;
   let _param4;
   _L: {
@@ -3596,10 +3494,10 @@ function moonbitlang$core$immut$list$$T$drop$48$(self, n) {
     }
   }
 }
-function moonbitlang$core$immut$hashmap$$new$49$() {
+function moonbitlang$core$immut$hashmap$$new$50$() {
   return $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Empty$7$;
 }
-function moonbitlang$core$immut$hashmap$$Bucket$find$49$(self, key) {
+function moonbitlang$core$immut$hashmap$$Bucket$find$50$(self, key) {
   let _tmp = self;
   let _tmp$2 = key;
   while (true) {
@@ -3609,13 +3507,13 @@ function moonbitlang$core$immut$hashmap$$Bucket$find$49$(self, key) {
       const _Just_One = self$2;
       const _x = _Just_One._0;
       const _x$2 = _Just_One._1;
-      return moonbitlang$core$builtin$$Eq$op_equal$50$(key$2, _x) ? _x$2 : undefined;
+      return moonbitlang$core$builtin$$Eq$op_equal$51$(key$2, _x) ? _x$2 : undefined;
     } else {
       const _More = self$2;
       const _x = _More._0;
       const _x$2 = _More._1;
       const _x$3 = _More._2;
-      if (moonbitlang$core$builtin$$Eq$op_equal$50$(key$2, _x)) {
+      if (moonbitlang$core$builtin$$Eq$op_equal$51$(key$2, _x)) {
         return _x$2;
       } else {
         _tmp = _x$3;
@@ -3624,9 +3522,9 @@ function moonbitlang$core$immut$hashmap$$Bucket$find$49$(self, key) {
     }
   }
 }
-function moonbitlang$core$immut$hashmap$$T$find$49$(self, key) {
+function moonbitlang$core$immut$hashmap$$T$find$50$(self, key) {
   let _tmp = self;
-  let _tmp$2 = moonbitlang$core$builtin$$Hash$hash$51$(key);
+  let _tmp$2 = moonbitlang$core$builtin$$Hash$hash$52$(key);
   _L: while (true) {
     const _param = _tmp;
     const _param$2 = _tmp$2;
@@ -3638,12 +3536,12 @@ function moonbitlang$core$immut$hashmap$$T$find$49$(self, key) {
         const _Leaf = _param;
         const _x = _Leaf._0;
         const _x$2 = _Leaf._1;
-        return moonbitlang$core$builtin$$Eq$op_equal$50$(key, _x) ? _x$2 : undefined;
+        return moonbitlang$core$builtin$$Eq$op_equal$51$(key, _x) ? _x$2 : undefined;
       }
       case 2: {
         const _Collision = _param;
         const _x$3 = _Collision._0;
-        return moonbitlang$core$immut$hashmap$$Bucket$find$49$(_x$3, key);
+        return moonbitlang$core$immut$hashmap$$Bucket$find$50$(_x$3, key);
       }
       default: {
         const _Branch = _param;
@@ -3661,80 +3559,71 @@ function moonbitlang$core$immut$hashmap$$T$find$49$(self, key) {
     }
   }
 }
-function moonbitlang$core$immut$hashmap$$T$op_get$49$(self, key) {
-  return moonbitlang$core$immut$hashmap$$T$find$49$(self, key);
+function moonbitlang$core$immut$hashmap$$T$op_get$50$(self, key) {
+  return moonbitlang$core$immut$hashmap$$T$find$50$(self, key);
 }
-function moonbitlang$core$immut$hashmap$$Bucket$add$49$(self, key, value) {
+function moonbitlang$core$immut$hashmap$$Bucket$add$50$(self, key, value) {
   if (self.$tag === 0) {
     const _Just_One = self;
     const _x = _Just_One._0;
-    return moonbitlang$core$builtin$$Eq$op_equal$50$(key, _x) ? new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$Just_One$7$(key, value) : new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$More$7$(key, value, self);
+    return moonbitlang$core$builtin$$Eq$op_equal$51$(key, _x) ? new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$Just_One$7$(key, value) : new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$More$7$(key, value, self);
   } else {
     const _More = self;
     const _x = _More._0;
     const _x$2 = _More._1;
     const _x$3 = _More._2;
-    return moonbitlang$core$builtin$$Eq$op_equal$50$(key, _x) ? new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$More$7$(key, value, _x$3) : new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$More$7$(_x, _x$2, moonbitlang$core$immut$hashmap$$Bucket$add$49$(_x$3, key, value));
+    return moonbitlang$core$builtin$$Eq$op_equal$51$(key, _x) ? new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$More$7$(key, value, _x$3) : new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$More$7$(_x, _x$2, moonbitlang$core$immut$hashmap$$Bucket$add$50$(_x$3, key, value));
   }
 }
-function moonbitlang$core$immut$hashmap$$T$add_with_hash$49$(self, key, depth, hash, value) {
+function moonbitlang$core$immut$hashmap$$T$add_with_hash$50$(self, key, depth, hash, value) {
   switch (self.$tag) {
     case 0: {
-      return moonbitlang$core$immut$hashmap$$add_with_hash$46$make_leaf$47$1005(depth, key, hash, value);
+      return moonbitlang$core$immut$hashmap$$add_with_hash$46$make_leaf$47$891(depth, key, hash, value);
     }
     case 1: {
       const _Leaf = self;
       const _x = _Leaf._0;
       const _x$2 = _Leaf._1;
-      return moonbitlang$core$builtin$$Eq$op_equal$50$(key, _x) ? new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Leaf$7$(key, value) : new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Collision$7$(new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$More$7$(key, value, new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$Just_One$7$(_x, _x$2)));
+      return moonbitlang$core$builtin$$Eq$op_equal$51$(key, _x) ? new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Leaf$7$(key, value) : new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Collision$7$(new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$More$7$(key, value, new $64$moonbitlang$47$core$47$immut$47$hashmap$46$Bucket$Just_One$7$(_x, _x$2)));
     }
     case 2: {
       const _Collision = self;
       const _x$3 = _Collision._0;
-      return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Collision$7$(moonbitlang$core$immut$hashmap$$Bucket$add$49$(_x$3, key, value));
+      return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Collision$7$(moonbitlang$core$immut$hashmap$$Bucket$add$50$(_x$3, key, value));
     }
     default: {
       const _Branch = self;
       const _x$4 = _Branch._0;
       const idx = hash & 31;
-      const _bind = moonbitlang$core$immut$internal$sparse_array$$SparseArray$op_get$33$(_x$4, idx);
+      const _bind = moonbitlang$core$immut$internal$sparse_array$$SparseArray$op_get$34$(_x$4, idx);
       if (_bind === undefined) {
-        const child = moonbitlang$core$immut$hashmap$$add_with_hash$46$make_leaf$47$1005(depth + 5 | 0, key, hash >>> 5 | 0, value);
-        return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Branch$7$(moonbitlang$core$immut$internal$sparse_array$$SparseArray$add$33$(_x$4, idx, child));
+        const child = moonbitlang$core$immut$hashmap$$add_with_hash$46$make_leaf$47$891(depth + 5 | 0, key, hash >>> 5 | 0, value);
+        return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Branch$7$(moonbitlang$core$immut$internal$sparse_array$$SparseArray$add$34$(_x$4, idx, child));
       } else {
         const _Some = _bind;
         const _x$5 = _Some;
-        const child = moonbitlang$core$immut$hashmap$$T$add_with_hash$49$(_x$5, key, depth + 5 | 0, hash >>> 5 | 0, value);
-        return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Branch$7$(moonbitlang$core$immut$internal$sparse_array$$SparseArray$replace$33$(_x$4, idx, child));
+        const child = moonbitlang$core$immut$hashmap$$T$add_with_hash$50$(_x$5, key, depth + 5 | 0, hash >>> 5 | 0, value);
+        return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Branch$7$(moonbitlang$core$immut$internal$sparse_array$$SparseArray$replace$34$(_x$4, idx, child));
       }
     }
   }
 }
-function moonbitlang$core$immut$hashmap$$add_with_hash$46$make_leaf$47$1005(depth, key, hash, value) {
+function moonbitlang$core$immut$hashmap$$add_with_hash$46$make_leaf$47$891(depth, key, hash, value) {
   if (depth >= 32) {
     return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Leaf$7$(key, value);
   } else {
     const idx = hash & 31;
-    const child = moonbitlang$core$immut$hashmap$$add_with_hash$46$make_leaf$47$1005(depth + 5 | 0, key, hash >>> 5 | 0, value);
-    return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Branch$7$(moonbitlang$core$immut$internal$sparse_array$$singleton$33$(idx, child));
+    const child = moonbitlang$core$immut$hashmap$$add_with_hash$46$make_leaf$47$891(depth + 5 | 0, key, hash >>> 5 | 0, value);
+    return new $64$moonbitlang$47$core$47$immut$47$hashmap$46$T$Branch$7$(moonbitlang$core$immut$internal$sparse_array$$singleton$34$(idx, child));
   }
 }
-function moonbitlang$core$immut$hashmap$$T$add$49$(self, key, value) {
-  return moonbitlang$core$immut$hashmap$$T$add_with_hash$49$(self, key, 0, moonbitlang$core$builtin$$Hash$hash$51$(key), value);
-}
-function moonbitlang$core$option$$Option$map$52$(self, f) {
-  if (self === undefined) {
-    return undefined;
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return f(_x);
-  }
+function moonbitlang$core$immut$hashmap$$T$add$50$(self, key, value) {
+  return moonbitlang$core$immut$hashmap$$T$add_with_hash$50$(self, key, 0, moonbitlang$core$builtin$$Hash$hash$52$(key), value);
 }
 function moonbitlang$core$option$$Option$is_empty$53$(self) {
   return self === undefined;
 }
-function moonbitlang$core$option$$Option$or$39$(self, default_) {
+function moonbitlang$core$option$$Option$or$40$(self, default_) {
   if (self === undefined) {
     return default_;
   } else {
@@ -3785,19 +3674,28 @@ function moonbitlang$core$sorted_map$$new_node$58$(key, value) {
 function moonbitlang$core$sorted_map$$Node$op_equal$55$(self, other) {
   return moonbitlang$core$builtin$$Eq$op_equal$59$(self.key, other.key);
 }
+function moonbitlang$core$sorted_map$$Node$op_equal$58$(self, other) {
+  return self.key === other.key;
+}
 function moonbitlang$core$sorted_map$$Node$op_equal$57$(self, other) {
   return moonbitlang$core$builtin$$Eq$op_equal$60$(self.key, other.key);
 }
 function moonbitlang$core$sorted_map$$Node$op_equal$56$(self, other) {
   return moonbitlang$core$builtin$$Eq$op_equal$61$(self.key, other.key);
 }
-function moonbitlang$core$sorted_map$$Node$op_equal$58$(self, other) {
-  return self.key === other.key;
-}
 function moonbitlang$core$sorted_map$$max(x, y) {
   return x > y ? x : y;
 }
 function moonbitlang$core$sorted_map$$height$55$(node) {
+  if (node === undefined) {
+    return 0;
+  } else {
+    const _Some = node;
+    const _x = _Some;
+    return _x.height;
+  }
+}
+function moonbitlang$core$sorted_map$$height$58$(node) {
   if (node === undefined) {
     return 0;
   } else {
@@ -3824,28 +3722,34 @@ function moonbitlang$core$sorted_map$$height$56$(node) {
     return _x.height;
   }
 }
-function moonbitlang$core$sorted_map$$height$58$(node) {
-  if (node === undefined) {
-    return 0;
-  } else {
-    const _Some = node;
-    const _x = _Some;
-    return _x.height;
-  }
-}
 function moonbitlang$core$sorted_map$$new$57$() {
   return { root: undefined, size: 0 };
 }
 function moonbitlang$core$sorted_map$$new$56$() {
   return { root: undefined, size: 0 };
 }
-function moonbitlang$core$sorted_map$$new$55$() {
-  return { root: undefined, size: 0 };
-}
 function moonbitlang$core$sorted_map$$new$58$() {
   return { root: undefined, size: 0 };
 }
+function moonbitlang$core$sorted_map$$new$55$() {
+  return { root: undefined, size: 0 };
+}
 function moonbitlang$core$sorted_map$$height_ge$55$(x1, x2) {
+  if (x2 === undefined) {
+    return true;
+  } else {
+    const _Some = x2;
+    const _x = _Some;
+    if (x1 === undefined) {
+      return false;
+    } else {
+      const _Some$2 = x1;
+      const _x$2 = _Some$2;
+      return _x$2.height >= _x.height;
+    }
+  }
+}
+function moonbitlang$core$sorted_map$$height_ge$58$(x1, x2) {
   if (x2 === undefined) {
     return true;
   } else {
@@ -3890,32 +3794,17 @@ function moonbitlang$core$sorted_map$$height_ge$56$(x1, x2) {
     }
   }
 }
-function moonbitlang$core$sorted_map$$height_ge$58$(x1, x2) {
-  if (x2 === undefined) {
-    return true;
-  } else {
-    const _Some = x2;
-    const _x = _Some;
-    if (x1 === undefined) {
-      return false;
-    } else {
-      const _Some$2 = x1;
-      const _x$2 = _Some$2;
-      return _x$2.height >= _x.height;
-    }
-  }
-}
 function moonbitlang$core$sorted_map$$Node$update_height$55$(self) {
   self.height = 1 + moonbitlang$core$sorted_map$$max(moonbitlang$core$sorted_map$$height$55$(self.left), moonbitlang$core$sorted_map$$height$55$(self.right)) | 0;
+}
+function moonbitlang$core$sorted_map$$Node$update_height$58$(self) {
+  self.height = 1 + moonbitlang$core$sorted_map$$max(moonbitlang$core$sorted_map$$height$58$(self.left), moonbitlang$core$sorted_map$$height$58$(self.right)) | 0;
 }
 function moonbitlang$core$sorted_map$$Node$update_height$57$(self) {
   self.height = 1 + moonbitlang$core$sorted_map$$max(moonbitlang$core$sorted_map$$height$57$(self.left), moonbitlang$core$sorted_map$$height$57$(self.right)) | 0;
 }
 function moonbitlang$core$sorted_map$$Node$update_height$56$(self) {
   self.height = 1 + moonbitlang$core$sorted_map$$max(moonbitlang$core$sorted_map$$height$56$(self.left), moonbitlang$core$sorted_map$$height$56$(self.right)) | 0;
-}
-function moonbitlang$core$sorted_map$$Node$update_height$58$(self) {
-  self.height = 1 + moonbitlang$core$sorted_map$$max(moonbitlang$core$sorted_map$$height$58$(self.left), moonbitlang$core$sorted_map$$height$58$(self.right)) | 0;
 }
 function moonbitlang$core$sorted_map$$rotate_l$55$(n) {
   const r = moonbitlang$core$option$$Option$unwrap$53$(n.right);
@@ -3925,8 +3814,16 @@ function moonbitlang$core$sorted_map$$rotate_l$55$(n) {
   moonbitlang$core$sorted_map$$Node$update_height$55$(r);
   return r;
 }
-function moonbitlang$core$sorted_map$$rotate_l$57$(n) {
+function moonbitlang$core$sorted_map$$rotate_l$58$(n) {
   const r = moonbitlang$core$option$$Option$unwrap$62$(n.right);
+  n.right = r.left;
+  r.left = n;
+  moonbitlang$core$sorted_map$$Node$update_height$58$(n);
+  moonbitlang$core$sorted_map$$Node$update_height$58$(r);
+  return r;
+}
+function moonbitlang$core$sorted_map$$rotate_l$57$(n) {
+  const r = moonbitlang$core$option$$Option$unwrap$63$(n.right);
   n.right = r.left;
   r.left = n;
   moonbitlang$core$sorted_map$$Node$update_height$57$(n);
@@ -3934,19 +3831,11 @@ function moonbitlang$core$sorted_map$$rotate_l$57$(n) {
   return r;
 }
 function moonbitlang$core$sorted_map$$rotate_l$56$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$63$(n.right);
+  const r = moonbitlang$core$option$$Option$unwrap$64$(n.right);
   n.right = r.left;
   r.left = n;
   moonbitlang$core$sorted_map$$Node$update_height$56$(n);
   moonbitlang$core$sorted_map$$Node$update_height$56$(r);
-  return r;
-}
-function moonbitlang$core$sorted_map$$rotate_l$58$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$64$(n.right);
-  n.right = r.left;
-  r.left = n;
-  moonbitlang$core$sorted_map$$Node$update_height$58$(n);
-  moonbitlang$core$sorted_map$$Node$update_height$58$(r);
   return r;
 }
 function moonbitlang$core$sorted_map$$rotate_r$55$(n) {
@@ -3957,8 +3846,16 @@ function moonbitlang$core$sorted_map$$rotate_r$55$(n) {
   moonbitlang$core$sorted_map$$Node$update_height$55$(l);
   return l;
 }
-function moonbitlang$core$sorted_map$$rotate_r$57$(n) {
+function moonbitlang$core$sorted_map$$rotate_r$58$(n) {
   const l = moonbitlang$core$option$$Option$unwrap$62$(n.left);
+  n.left = l.right;
+  l.right = n;
+  moonbitlang$core$sorted_map$$Node$update_height$58$(n);
+  moonbitlang$core$sorted_map$$Node$update_height$58$(l);
+  return l;
+}
+function moonbitlang$core$sorted_map$$rotate_r$57$(n) {
+  const l = moonbitlang$core$option$$Option$unwrap$63$(n.left);
   n.left = l.right;
   l.right = n;
   moonbitlang$core$sorted_map$$Node$update_height$57$(n);
@@ -3966,19 +3863,11 @@ function moonbitlang$core$sorted_map$$rotate_r$57$(n) {
   return l;
 }
 function moonbitlang$core$sorted_map$$rotate_r$56$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$63$(n.left);
+  const l = moonbitlang$core$option$$Option$unwrap$64$(n.left);
   n.left = l.right;
   l.right = n;
   moonbitlang$core$sorted_map$$Node$update_height$56$(n);
   moonbitlang$core$sorted_map$$Node$update_height$56$(l);
-  return l;
-}
-function moonbitlang$core$sorted_map$$rotate_r$58$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$64$(n.left);
-  n.left = l.right;
-  l.right = n;
-  moonbitlang$core$sorted_map$$Node$update_height$58$(n);
-  moonbitlang$core$sorted_map$$Node$update_height$58$(l);
   return l;
 }
 function moonbitlang$core$sorted_map$$rotate_lr$55$(n) {
@@ -3987,23 +3876,23 @@ function moonbitlang$core$sorted_map$$rotate_lr$55$(n) {
   n.left = v;
   return moonbitlang$core$sorted_map$$rotate_r$55$(n);
 }
-function moonbitlang$core$sorted_map$$rotate_lr$57$(n) {
+function moonbitlang$core$sorted_map$$rotate_lr$58$(n) {
   const l = moonbitlang$core$option$$Option$unwrap$62$(n.left);
+  const v = moonbitlang$core$sorted_map$$rotate_l$58$(l);
+  n.left = v;
+  return moonbitlang$core$sorted_map$$rotate_r$58$(n);
+}
+function moonbitlang$core$sorted_map$$rotate_lr$57$(n) {
+  const l = moonbitlang$core$option$$Option$unwrap$63$(n.left);
   const v = moonbitlang$core$sorted_map$$rotate_l$57$(l);
   n.left = v;
   return moonbitlang$core$sorted_map$$rotate_r$57$(n);
 }
 function moonbitlang$core$sorted_map$$rotate_lr$56$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$63$(n.left);
+  const l = moonbitlang$core$option$$Option$unwrap$64$(n.left);
   const v = moonbitlang$core$sorted_map$$rotate_l$56$(l);
   n.left = v;
   return moonbitlang$core$sorted_map$$rotate_r$56$(n);
-}
-function moonbitlang$core$sorted_map$$rotate_lr$58$(n) {
-  const l = moonbitlang$core$option$$Option$unwrap$64$(n.left);
-  const v = moonbitlang$core$sorted_map$$rotate_l$58$(l);
-  n.left = v;
-  return moonbitlang$core$sorted_map$$rotate_r$58$(n);
 }
 function moonbitlang$core$sorted_map$$rotate_rl$55$(n) {
   const r = moonbitlang$core$option$$Option$unwrap$53$(n.right);
@@ -4011,23 +3900,23 @@ function moonbitlang$core$sorted_map$$rotate_rl$55$(n) {
   n.right = v;
   return moonbitlang$core$sorted_map$$rotate_l$55$(n);
 }
-function moonbitlang$core$sorted_map$$rotate_rl$57$(n) {
+function moonbitlang$core$sorted_map$$rotate_rl$58$(n) {
   const r = moonbitlang$core$option$$Option$unwrap$62$(n.right);
+  const v = moonbitlang$core$sorted_map$$rotate_r$58$(r);
+  n.right = v;
+  return moonbitlang$core$sorted_map$$rotate_l$58$(n);
+}
+function moonbitlang$core$sorted_map$$rotate_rl$57$(n) {
+  const r = moonbitlang$core$option$$Option$unwrap$63$(n.right);
   const v = moonbitlang$core$sorted_map$$rotate_r$57$(r);
   n.right = v;
   return moonbitlang$core$sorted_map$$rotate_l$57$(n);
 }
 function moonbitlang$core$sorted_map$$rotate_rl$56$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$63$(n.right);
+  const r = moonbitlang$core$option$$Option$unwrap$64$(n.right);
   const v = moonbitlang$core$sorted_map$$rotate_r$56$(r);
   n.right = v;
   return moonbitlang$core$sorted_map$$rotate_l$56$(n);
-}
-function moonbitlang$core$sorted_map$$rotate_rl$58$(n) {
-  const r = moonbitlang$core$option$$Option$unwrap$64$(n.right);
-  const v = moonbitlang$core$sorted_map$$rotate_r$58$(r);
-  n.right = v;
-  return moonbitlang$core$sorted_map$$rotate_l$58$(n);
 }
 function moonbitlang$core$sorted_map$$balance$55$(root) {
   const l = root.left;
@@ -4060,13 +3949,13 @@ function moonbitlang$core$sorted_map$$balance$56$(root) {
   const hr = moonbitlang$core$sorted_map$$height$56$(r);
   let new_root;
   if (hl > (hr + 1 | 0)) {
-    const _bind = moonbitlang$core$option$$Option$unwrap$63$(l);
+    const _bind = moonbitlang$core$option$$Option$unwrap$64$(l);
     const _x = _bind.left;
     const _x$2 = _bind.right;
     new_root = moonbitlang$core$sorted_map$$height_ge$56$(_x, _x$2) ? moonbitlang$core$sorted_map$$rotate_r$56$(root) : moonbitlang$core$sorted_map$$rotate_lr$56$(root);
   } else {
     if (hr > (hl + 1 | 0)) {
-      const _bind = moonbitlang$core$option$$Option$unwrap$63$(r);
+      const _bind = moonbitlang$core$option$$Option$unwrap$64$(r);
       const _x = _bind.left;
       const _x$2 = _bind.right;
       new_root = moonbitlang$core$sorted_map$$height_ge$56$(_x$2, _x) ? moonbitlang$core$sorted_map$$rotate_l$56$(root) : moonbitlang$core$sorted_map$$rotate_rl$56$(root);
@@ -4084,13 +3973,13 @@ function moonbitlang$core$sorted_map$$balance$57$(root) {
   const hr = moonbitlang$core$sorted_map$$height$57$(r);
   let new_root;
   if (hl > (hr + 1 | 0)) {
-    const _bind = moonbitlang$core$option$$Option$unwrap$62$(l);
+    const _bind = moonbitlang$core$option$$Option$unwrap$63$(l);
     const _x = _bind.left;
     const _x$2 = _bind.right;
     new_root = moonbitlang$core$sorted_map$$height_ge$57$(_x, _x$2) ? moonbitlang$core$sorted_map$$rotate_r$57$(root) : moonbitlang$core$sorted_map$$rotate_lr$57$(root);
   } else {
     if (hr > (hl + 1 | 0)) {
-      const _bind = moonbitlang$core$option$$Option$unwrap$62$(r);
+      const _bind = moonbitlang$core$option$$Option$unwrap$63$(r);
       const _x = _bind.left;
       const _x$2 = _bind.right;
       new_root = moonbitlang$core$sorted_map$$height_ge$57$(_x$2, _x) ? moonbitlang$core$sorted_map$$rotate_l$57$(root) : moonbitlang$core$sorted_map$$rotate_rl$57$(root);
@@ -4108,13 +3997,13 @@ function moonbitlang$core$sorted_map$$balance$58$(root) {
   const hr = moonbitlang$core$sorted_map$$height$58$(r);
   let new_root;
   if (hl > (hr + 1 | 0)) {
-    const _bind = moonbitlang$core$option$$Option$unwrap$64$(l);
+    const _bind = moonbitlang$core$option$$Option$unwrap$62$(l);
     const _x = _bind.left;
     const _x$2 = _bind.right;
     new_root = moonbitlang$core$sorted_map$$height_ge$58$(_x, _x$2) ? moonbitlang$core$sorted_map$$rotate_r$58$(root) : moonbitlang$core$sorted_map$$rotate_lr$58$(root);
   } else {
     if (hr > (hl + 1 | 0)) {
-      const _bind = moonbitlang$core$option$$Option$unwrap$64$(r);
+      const _bind = moonbitlang$core$option$$Option$unwrap$62$(r);
       const _x = _bind.left;
       const _x$2 = _bind.right;
       new_root = moonbitlang$core$sorted_map$$height_ge$58$(_x$2, _x) ? moonbitlang$core$sorted_map$$rotate_l$58$(root) : moonbitlang$core$sorted_map$$rotate_rl$58$(root);
@@ -4149,6 +4038,34 @@ function moonbitlang$core$sorted_map$$add_node$55$(root, key, value) {
         const _x$3 = _bind._1;
         _x.right = _x$2;
         return { _0: moonbitlang$core$sorted_map$$balance$55$(_x), _1: _x$3 };
+      }
+    }
+  }
+}
+function moonbitlang$core$sorted_map$$add_node$58$(root, key, value) {
+  if (root === undefined) {
+    return { _0: moonbitlang$core$sorted_map$$new_node$58$(key, value), _1: true };
+  } else {
+    const _Some = root;
+    const _x = _Some;
+    if (key === _x.key) {
+      _x.value = value;
+      return { _0: _x, _1: false };
+    } else {
+      const l = _x.left;
+      const r = _x.right;
+      if (moonbitlang$core$builtin$$op_lt$10$(key, _x.key)) {
+        const _bind = moonbitlang$core$sorted_map$$add_node$58$(l, key, value);
+        const _x$2 = _bind._0;
+        const _x$3 = _bind._1;
+        _x.left = _x$2;
+        return { _0: moonbitlang$core$sorted_map$$balance$58$(_x), _1: _x$3 };
+      } else {
+        const _bind = moonbitlang$core$sorted_map$$add_node$58$(r, key, value);
+        const _x$2 = _bind._0;
+        const _x$3 = _bind._1;
+        _x.right = _x$2;
+        return { _0: moonbitlang$core$sorted_map$$balance$58$(_x), _1: _x$3 };
       }
     }
   }
@@ -4205,34 +4122,6 @@ function moonbitlang$core$sorted_map$$add_node$56$(root, key, value) {
         const _x$3 = _bind._1;
         _x.right = _x$2;
         return { _0: moonbitlang$core$sorted_map$$balance$56$(_x), _1: _x$3 };
-      }
-    }
-  }
-}
-function moonbitlang$core$sorted_map$$add_node$58$(root, key, value) {
-  if (root === undefined) {
-    return { _0: moonbitlang$core$sorted_map$$new_node$58$(key, value), _1: true };
-  } else {
-    const _Some = root;
-    const _x = _Some;
-    if (key === _x.key) {
-      _x.value = value;
-      return { _0: _x, _1: false };
-    } else {
-      const l = _x.left;
-      const r = _x.right;
-      if (moonbitlang$core$builtin$$op_lt$10$(key, _x.key)) {
-        const _bind = moonbitlang$core$sorted_map$$add_node$58$(l, key, value);
-        const _x$2 = _bind._0;
-        const _x$3 = _bind._1;
-        _x.left = _x$2;
-        return { _0: moonbitlang$core$sorted_map$$balance$58$(_x), _1: _x$3 };
-      } else {
-        const _bind = moonbitlang$core$sorted_map$$add_node$58$(r, key, value);
-        const _x$2 = _bind._0;
-        const _x$3 = _bind._1;
-        _x.right = _x$2;
-        return { _0: moonbitlang$core$sorted_map$$balance$58$(_x), _1: _x$3 };
       }
     }
   }
@@ -4296,14 +4185,14 @@ function moonbitlang$core$sorted_map$$T$add$58$(self, key, value) {
 function moonbitlang$core$sorted_map$$T$op_set$55$(self, key, value) {
   moonbitlang$core$sorted_map$$T$add$55$(self, key, value);
 }
+function moonbitlang$core$sorted_map$$T$op_set$58$(self, key, value) {
+  moonbitlang$core$sorted_map$$T$add$58$(self, key, value);
+}
 function moonbitlang$core$sorted_map$$T$op_set$57$(self, key, value) {
   moonbitlang$core$sorted_map$$T$add$57$(self, key, value);
 }
 function moonbitlang$core$sorted_map$$T$op_set$56$(self, key, value) {
   moonbitlang$core$sorted_map$$T$add$56$(self, key, value);
-}
-function moonbitlang$core$sorted_map$$T$op_set$58$(self, key, value) {
-  moonbitlang$core$sorted_map$$T$add$58$(self, key, value);
 }
 function moonbitlang$core$sorted_map$$T$get$55$(self, key) {
   let _tmp = self.root;
@@ -4407,11 +4296,11 @@ function moonbitlang$core$sorted_map$$T$op_get$57$(self, key) {
 function moonbitlang$core$sorted_map$$T$op_get$55$(self, key) {
   return moonbitlang$core$sorted_map$$T$get$55$(self, key);
 }
-function moonbitlang$core$sorted_map$$T$op_get$56$(self, key) {
-  return moonbitlang$core$sorted_map$$T$get$56$(self, key);
-}
 function moonbitlang$core$sorted_map$$T$op_get$58$(self, key) {
   return moonbitlang$core$sorted_map$$T$get$58$(self, key);
+}
+function moonbitlang$core$sorted_map$$T$op_get$56$(self, key) {
+  return moonbitlang$core$sorted_map$$T$get$56$(self, key);
 }
 function moonbitlang$core$sorted_map$$T$each$55$(self, f) {
   const s = [];
@@ -4455,7 +4344,7 @@ function moonbitlang$core$sorted_map$$iter_aux2$57$(node) {
     } else {
       const _Some = node;
       const _x = _Some;
-      return moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter2$run$57$(moonbitlang$core$sorted_map$$iter_aux2$57$(_x.left), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x.key, _x.value), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter2$run$57$(moonbitlang$core$sorted_map$$iter_aux2$57$(_x.right), yield_), 0) ? 0 : 1;
+      return moonbitlang$core$builtin$$Eq$op_equal$13$(moonbitlang$core$builtin$$Iter2$run$57$(moonbitlang$core$sorted_map$$iter_aux2$57$(_x.left), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(_x.key, _x.value), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$13$(moonbitlang$core$builtin$$Iter2$run$57$(moonbitlang$core$sorted_map$$iter_aux2$57$(_x.right), yield_), 0) ? 0 : 1;
     }
   });
 }
@@ -4466,7 +4355,7 @@ function moonbitlang$core$sorted_map$$iter_aux2$56$(node) {
     } else {
       const _Some = node;
       const _x = _Some;
-      return moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter2$run$56$(moonbitlang$core$sorted_map$$iter_aux2$56$(_x.left), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x.key, _x.value), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter2$run$56$(moonbitlang$core$sorted_map$$iter_aux2$56$(_x.right), yield_), 0) ? 0 : 1;
+      return moonbitlang$core$builtin$$Eq$op_equal$13$(moonbitlang$core$builtin$$Iter2$run$56$(moonbitlang$core$sorted_map$$iter_aux2$56$(_x.left), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(_x.key, _x.value), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$13$(moonbitlang$core$builtin$$Iter2$run$56$(moonbitlang$core$sorted_map$$iter_aux2$56$(_x.right), yield_), 0) ? 0 : 1;
     }
   });
 }
@@ -4477,18 +4366,7 @@ function moonbitlang$core$sorted_map$$iter_aux2$55$(node) {
     } else {
       const _Some = node;
       const _x = _Some;
-      return moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter2$run$55$(moonbitlang$core$sorted_map$$iter_aux2$55$(_x.left), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x.key, _x.value), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter2$run$55$(moonbitlang$core$sorted_map$$iter_aux2$55$(_x.right), yield_), 0) ? 0 : 1;
-    }
-  });
-}
-function moonbitlang$core$sorted_map$$iter_aux2$58$(node) {
-  return moonbitlang$core$builtin$$Iter2$new$58$((yield_) => {
-    if (node === undefined) {
-      return 1;
-    } else {
-      const _Some = node;
-      const _x = _Some;
-      return moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter2$run$58$(moonbitlang$core$sorted_map$$iter_aux2$58$(_x.left), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x.key, _x.value), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter2$run$58$(moonbitlang$core$sorted_map$$iter_aux2$58$(_x.right), yield_), 0) ? 0 : 1;
+      return moonbitlang$core$builtin$$Eq$op_equal$13$(moonbitlang$core$builtin$$Iter2$run$55$(moonbitlang$core$sorted_map$$iter_aux2$55$(_x.left), yield_), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(_x.key, _x.value), 0) ? 0 : moonbitlang$core$builtin$$Eq$op_equal$13$(moonbitlang$core$builtin$$Iter2$run$55$(moonbitlang$core$sorted_map$$iter_aux2$55$(_x.right), yield_), 0) ? 0 : 1;
     }
   });
 }
@@ -4500,9 +4378,6 @@ function moonbitlang$core$sorted_map$$T$iter2$56$(self) {
 }
 function moonbitlang$core$sorted_map$$T$iter2$57$(self) {
   return moonbitlang$core$sorted_map$$iter_aux2$57$(self.root);
-}
-function moonbitlang$core$sorted_map$$T$iter2$58$(self) {
-  return moonbitlang$core$sorted_map$$iter_aux2$58$(self.root);
 }
 function moonbitlang$core$hashmap$$power_2_above(x, n) {
   let _tmp = x;
@@ -4543,7 +4418,7 @@ function moonbitlang$core$hashmap$$T$set_with_hash$69$(self, key, value, hash) {
     } else {
       const _Some = _bind;
       const _x = _Some;
-      if (_x.hash === entry.hash && moonbitlang$core$builtin$$Eq$op_equal$36$(_x.key, entry.key)) {
+      if (_x.hash === entry.hash && moonbitlang$core$builtin$$Eq$op_equal$37$(_x.key, entry.key)) {
         _x.value = entry.value;
         break;
       }
@@ -4607,7 +4482,7 @@ function moonbitlang$core$hashmap$$T$get_with_hash$69$(self, key, hash) {
     } else {
       const _Some = _bind;
       const _x = _Some;
-      if (_x.hash === hash && moonbitlang$core$builtin$$Eq$op_equal$36$(_x.key, key)) {
+      if (_x.hash === hash && moonbitlang$core$builtin$$Eq$op_equal$37$(_x.key, key)) {
         return _x.value;
       }
       if (i > _x.psl) {
@@ -4644,7 +4519,7 @@ function moonbitlang$core$hashmap$$T$iter$69$(self) {
             const _x = _Some;
             const _x$2 = _x.key;
             const _x$3 = _x.value;
-            if (moonbitlang$core$builtin$$Eq$op_equal$15$(yield_({ _0: _x$2, _1: _x$3 }), 0)) {
+            if (moonbitlang$core$builtin$$Eq$op_equal$13$(yield_({ _0: _x$2, _1: _x$3 }), 0)) {
               return 0;
             }
           }
@@ -4668,57 +4543,53 @@ function moonbitlang$core$json$$escape(str, escape_slash) {
   const buf = moonbitlang$core$builtin$$StringBuilder$new(str.length);
   const _bind = moonbitlang$core$string$$String$iter(str);
   _bind((c) => {
-    _L: {
-      _L$2: {
-        switch (c) {
-          case 34: {
-            break _L$2;
-          }
-          case 92: {
-            break _L$2;
-          }
-          case 47: {
-            if (escape_slash) {
-              moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\/");
-            } else {
-              moonbitlang$core$builtin$$StringBuilder$write_char(buf, c);
-            }
-            break;
-          }
-          case 10: {
-            moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\n");
-            break;
-          }
-          case 13: {
-            moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\r");
-            break;
-          }
-          case 8: {
-            moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\b");
-            break;
-          }
-          case 9: {
-            moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\t");
-            break;
-          }
-          default: {
-            const code = c;
-            if (code === 12) {
-              moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\f");
-            } else {
-              if (code < 32) {
-                moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\u00");
-                moonbitlang$core$builtin$$StringBuilder$write_char(buf, moonbitlang$core$json$$escape$46$to_hex_digit$72$(code / 16 | 0));
-                moonbitlang$core$builtin$$StringBuilder$write_char(buf, moonbitlang$core$json$$escape$46$to_hex_digit$72$(code % 16 | 0));
-              } else {
-                moonbitlang$core$builtin$$StringBuilder$write_char(buf, c);
-              }
-            }
+    switch (c) {
+      case 34: {
+        moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\\"");
+        break;
+      }
+      case 92: {
+        moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\\\");
+        break;
+      }
+      case 47: {
+        if (escape_slash) {
+          moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\/");
+        } else {
+          moonbitlang$core$builtin$$StringBuilder$write_char(buf, c);
+        }
+        break;
+      }
+      case 10: {
+        moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\n");
+        break;
+      }
+      case 13: {
+        moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\r");
+        break;
+      }
+      case 8: {
+        moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\b");
+        break;
+      }
+      case 9: {
+        moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\t");
+        break;
+      }
+      default: {
+        const code = c;
+        if (code === 12) {
+          moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\f");
+        } else {
+          if (code < 32) {
+            moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\u00");
+            moonbitlang$core$builtin$$StringBuilder$write_char(buf, moonbitlang$core$json$$escape$46$to_hex_digit$72$(code / 16 | 0));
+            moonbitlang$core$builtin$$StringBuilder$write_char(buf, moonbitlang$core$json$$escape$46$to_hex_digit$72$(code % 16 | 0));
+          } else {
+            moonbitlang$core$builtin$$StringBuilder$write_char(buf, c);
           }
         }
-        break _L;
       }
-      moonbitlang$core$builtin$$StringBuilder$write_string(buf, `\\${String.fromCodePoint(c)}`);
     }
     return 1;
   });
@@ -4823,34 +4694,34 @@ function moonbitlang$core$json$$Json$stringify(self, escape_slash, indent) {
 function moonbitlang$core$json$$Json$stringify$46$escape_slash$46$default() {
   return false;
 }
-function moonbitlang$core$builtin$$abort$12$(msg) {
-  return $panic();
-}
 function moonbitlang$core$builtin$$abort$14$(msg) {
   return $panic();
 }
-function moonbitlang$core$builtin$$abort$13$(msg) {
+function moonbitlang$core$builtin$$abort$17$(msg) {
+  return $panic();
+}
+function moonbitlang$core$builtin$$abort$16$(msg) {
   return $panic();
 }
 function moonbitlang$core$builtin$$abort$76$(msg) {
   return $panic();
 }
-function moonbitlang$core$builtin$$abort$31$(msg) {
+function moonbitlang$core$builtin$$abort$32$(msg) {
   return $panic();
 }
-function moonbitlang$core$builtin$$abort$39$(msg) {
+function moonbitlang$core$builtin$$abort$40$(msg) {
   return $panic();
 }
 function moonbitlang$core$builtin$$abort$77$(msg) {
   return $panic();
 }
-function moonbitlang$core$builtin$$abort$32$(msg) {
+function moonbitlang$core$builtin$$abort$33$(msg) {
   return $panic();
 }
 function moonbitlang$core$builtin$$abort$78$(msg) {
   return $panic();
 }
-function moonbitlang$core$builtin$$abort$48$(msg) {
+function moonbitlang$core$builtin$$abort$49$(msg) {
   return $panic();
 }
 function moonbitlang$core$builtin$$abort$79$(msg) {
@@ -4868,23 +4739,17 @@ function moonbitlang$core$builtin$$abort$82$(msg) {
 function moonbitlang$core$builtin$$abort$9$(msg) {
   return $panic();
 }
+function moonbitlang$core$builtin$$abort$20$(msg) {
+  return $panic();
+}
 function moonbitlang$core$builtin$$abort$8$(msg) {
   $panic();
-}
-function moonbitlang$core$builtin$$abort$17$(msg) {
-  return $panic();
 }
 function moonbitlang$core$builtin$$abort$10$(msg) {
   return $panic();
 }
 function moonbitlang$core$builtin$$rotl(x, r) {
   return x << r | (x >>> (32 - r | 0) | 0);
-}
-function moonbitlang$core$builtin$$op_ge$7$(self_, other) {
-  return moonbitlang$core$int64$$Int64$compare(self_, other) >= 0;
-}
-function moonbitlang$core$builtin$$op_le$7$(self_, other) {
-  return moonbitlang$core$int64$$Int64$compare(self_, other) <= 0;
 }
 function moonbitlang$core$builtin$$StringBuilder$new(size_hint) {
   return { val: "" };
@@ -4898,29 +4763,26 @@ function moonbitlang$core$builtin$$StringBuilder$to_string(self) {
 function moonbitlang$core$builtin$$op_notequal$65$(x, y) {
   return !moonbitlang$core$option$$Option$op_equal$53$(x, y);
 }
-function moonbitlang$core$builtin$$op_notequal$67$(x, y) {
-  return !moonbitlang$core$option$$Option$op_equal$62$(x, y);
-}
-function moonbitlang$core$builtin$$op_notequal$66$(x, y) {
-  return !moonbitlang$core$option$$Option$op_equal$63$(x, y);
+function moonbitlang$core$builtin$$op_notequal$13$(x, y) {
+  return !moonbitlang$core$builtin$$Eq$op_equal$13$(x, y);
 }
 function moonbitlang$core$builtin$$op_notequal$68$(x, y) {
+  return !moonbitlang$core$option$$Option$op_equal$62$(x, y);
+}
+function moonbitlang$core$builtin$$op_notequal$67$(x, y) {
+  return !moonbitlang$core$option$$Option$op_equal$63$(x, y);
+}
+function moonbitlang$core$builtin$$op_notequal$66$(x, y) {
   return !moonbitlang$core$option$$Option$op_equal$64$(x, y);
 }
-function moonbitlang$core$builtin$$op_notequal$42$(x, y) {
-  return !moonbitlang$core$builtin$$Eq$op_equal$42$(x, y);
+function moonbitlang$core$builtin$$op_notequal$43$(x, y) {
+  return !moonbitlang$core$builtin$$Eq$op_equal$43$(x, y);
+}
+function moonbitlang$core$builtin$$op_notequal$26$(x, y) {
+  return !moonbitlang$core$option$$Option$op_equal$23$(x, y);
 }
 function moonbitlang$core$builtin$$op_notequal$25$(x, y) {
-  return !moonbitlang$core$option$$Option$op_equal$20$(x, y);
-}
-function moonbitlang$core$builtin$$op_notequal$24$(x, y) {
-  return !moonbitlang$core$option$$Option$op_equal$21$(x, y);
-}
-function moonbitlang$core$builtin$$op_notequal$15$(x, y) {
-  return !moonbitlang$core$builtin$$Eq$op_equal$15$(x, y);
-}
-function moonbitlang$core$builtin$$op_notequal$23$(x, y) {
-  return !moonbitlang$core$option$$Option$op_equal$22$(x, y);
+  return !moonbitlang$core$option$$Option$op_equal$24$(x, y);
 }
 function moonbitlang$core$builtin$$op_notequal$83$(x, y) {
   return !moonbitlang$core$builtin$$Eq$op_equal$83$(x, y);
@@ -4945,11 +4807,14 @@ function moonbitlang$core$builtin$$op_lt$61$(self_, other) {
 function moonbitlang$core$builtin$$op_lt$60$(self_, other) {
   return moonbitlang$core$builtin$$Compare$compare$60$(self_, other) < 0;
 }
+function moonbitlang$core$builtin$$op_lt$10$(self_, other) {
+  return moonbitlang$core$string$$String$compare(self_, other) < 0;
+}
 function moonbitlang$core$builtin$$op_lt$7$(self_, other) {
   return moonbitlang$core$int64$$Int64$compare(self_, other) < 0;
 }
-function moonbitlang$core$builtin$$op_lt$10$(self_, other) {
-  return moonbitlang$core$string$$String$compare(self_, other) < 0;
+function moonbitlang$core$builtin$$op_ge$7$(self_, other) {
+  return moonbitlang$core$int64$$Int64$compare(self_, other) >= 0;
 }
 function moonbitlang$core$array$$Array$op_get$85$(self, index) {
   const len = self.length;
@@ -4968,6 +4833,10 @@ function moonbitlang$core$array$$Array$op_get$9$(self, index) {
   return index >= 0 && index < len ? self[index] : $panic();
 }
 function moonbitlang$core$array$$Array$op_get$88$(self, index) {
+  const len = self.length;
+  return index >= 0 && index < len ? self[index] : $panic();
+}
+function moonbitlang$core$array$$Array$op_get$12$(self, index) {
   const len = self.length;
   return index >= 0 && index < len ? self[index] : $panic();
 }
@@ -4995,7 +4864,7 @@ function moonbitlang$core$array$$Array$op_get$93$(self, index) {
   const len = self.length;
   return index >= 0 && index < len ? self[index] : $panic();
 }
-function moonbitlang$core$array$$Array$op_get$32$(self, index) {
+function moonbitlang$core$array$$Array$op_get$33$(self, index) {
   const len = self.length;
   return index >= 0 && index < len ? self[index] : $panic();
 }
@@ -5019,6 +4888,9 @@ function moonbitlang$core$array$$Array$op_get$95$(self, index) {
   const len = self.length;
   return index >= 0 && index < len ? self[index] : $panic();
 }
+function moonbitlang$core$builtin$$op_le$7$(self_, other) {
+  return moonbitlang$core$int64$$Int64$compare(self_, other) <= 0;
+}
 function moonbitlang$core$builtin$$StringBuilder$write_char(self, ch) {
   const _bind = self;
   _bind.val = `${_bind.val}${String.fromCodePoint(ch)}`;
@@ -5027,14 +4899,35 @@ function moonbitlang$core$builtin$$StringBuilder$write_string(self, str) {
   const _bind = self;
   _bind.val = `${_bind.val}${str}`;
 }
+function moonbitlang$core$bytes$$Bytes$makei(length, value) {
+  if (length <= 0) {
+    return new Uint8Array([]);
+  }
+  const arr = $make_array_len_and_init(length, value(0));
+  let _tmp = 1;
+  while (true) {
+    const i = _tmp;
+    if (i < length) {
+      arr[i] = value(i);
+      _tmp = i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$builtin$$Logger$write_object$10$(self, obj) {
+  moonbitlang$core$builtin$$Show$output$10$(obj, self);
+}
 function moonbitlang$core$builtin$$Logger$write_object$89$(self, obj) {
   moonbitlang$core$builtin$$Show$output$89$(obj, self);
 }
 function moonbitlang$core$builtin$$Logger$write_object$61$(self, obj) {
   moonbitlang$core$builtin$$Show$output$61$(obj, self);
 }
-function moonbitlang$core$builtin$$Logger$write_object$18$(self, obj) {
-  moonbitlang$core$builtin$$Show$output$18$(obj, self);
+function moonbitlang$core$builtin$$Logger$write_object$96$(self, obj) {
+  moonbitlang$core$builtin$$Show$output$96$(obj, self);
 }
 function moonbitlang$core$builtin$$Logger$write_object$60$(self, obj) {
   moonbitlang$core$builtin$$Show$output$60$(obj, self);
@@ -5084,11 +4977,11 @@ function moonbitlang$core$builtin$$StringBuilder$write_substring(self, str, star
   const _bind = self;
   _bind.val = `${_bind.val}${moonbitlang$core$string$$String$substring(str, start, start + len | 0)}`;
 }
-function moonbitlang$core$builtin$$Hasher$combine$36$(self, value) {
-  moonbitlang$core$builtin$$Hash$hash_combine$36$(value, self);
+function moonbitlang$core$builtin$$Hasher$combine$37$(self, value) {
+  moonbitlang$core$builtin$$Hash$hash_combine$37$(value, self);
 }
-function moonbitlang$core$builtin$$Hasher$combine$96$(self, value) {
-  moonbitlang$core$builtin$$Hash$hash_combine$96$(value, self);
+function moonbitlang$core$builtin$$Hasher$combine$97$(self, value) {
+  moonbitlang$core$builtin$$Hash$hash_combine$97$(value, self);
 }
 function moonbitlang$core$builtin$$Hasher$combine$61$(self, value) {
   moonbitlang$core$builtin$$Hash$hash_combine$61$(value, self);
@@ -5096,8 +4989,8 @@ function moonbitlang$core$builtin$$Hasher$combine$61$(self, value) {
 function moonbitlang$core$builtin$$Hasher$combine$10$(self, value) {
   moonbitlang$core$builtin$$Hash$hash_combine$10$(value, self);
 }
-function moonbitlang$core$builtin$$Hasher$combine$50$(self, value) {
-  moonbitlang$core$builtin$$Hash$hash_combine$50$(value, self);
+function moonbitlang$core$builtin$$Hasher$combine$51$(self, value) {
+  moonbitlang$core$builtin$$Hash$hash_combine$51$(value, self);
 }
 function moonbitlang$core$builtin$$power_2_above(x, n) {
   let _tmp = x;
@@ -5121,10 +5014,6 @@ function moonbitlang$core$builtin$$Map$new$74$(capacity) {
   const capacity$2 = moonbitlang$core$builtin$$power_2_above(8, capacity);
   return { entries: $make_array_len_and_init(capacity$2, undefined), list: $make_array_len_and_init(capacity$2, { prev: undefined, next: undefined }), size: 0, capacity: capacity$2, capacity_mask: capacity$2 - 1 | 0, growAt: moonbitlang$core$builtin$$calc_grow_threshold(capacity$2), head: undefined, tail: undefined };
 }
-function moonbitlang$core$builtin$$Map$new$97$(capacity) {
-  const capacity$2 = moonbitlang$core$builtin$$power_2_above(8, capacity);
-  return { entries: $make_array_len_and_init(capacity$2, undefined), list: $make_array_len_and_init(capacity$2, { prev: undefined, next: undefined }), size: 0, capacity: capacity$2, capacity_mask: capacity$2 - 1 | 0, growAt: moonbitlang$core$builtin$$calc_grow_threshold(capacity$2), head: undefined, tail: undefined };
-}
 function moonbitlang$core$builtin$$Map$new$98$(capacity) {
   const capacity$2 = moonbitlang$core$builtin$$power_2_above(8, capacity);
   return { entries: $make_array_len_and_init(capacity$2, undefined), list: $make_array_len_and_init(capacity$2, { prev: undefined, next: undefined }), size: 0, capacity: capacity$2, capacity_mask: capacity$2 - 1 | 0, growAt: moonbitlang$core$builtin$$calc_grow_threshold(capacity$2), head: undefined, tail: undefined };
@@ -5141,50 +5030,17 @@ function moonbitlang$core$builtin$$Map$new$101$(capacity) {
   const capacity$2 = moonbitlang$core$builtin$$power_2_above(8, capacity);
   return { entries: $make_array_len_and_init(capacity$2, undefined), list: $make_array_len_and_init(capacity$2, { prev: undefined, next: undefined }), size: 0, capacity: capacity$2, capacity_mask: capacity$2 - 1 | 0, growAt: moonbitlang$core$builtin$$calc_grow_threshold(capacity$2), head: undefined, tail: undefined };
 }
-function moonbitlang$core$array$$Array$each$102$(self, f) {
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      return;
-    }
-  }
+function moonbitlang$core$builtin$$Map$new$102$(capacity) {
+  const capacity$2 = moonbitlang$core$builtin$$power_2_above(8, capacity);
+  return { entries: $make_array_len_and_init(capacity$2, undefined), list: $make_array_len_and_init(capacity$2, { prev: undefined, next: undefined }), size: 0, capacity: capacity$2, capacity_mask: capacity$2 - 1 | 0, growAt: moonbitlang$core$builtin$$calc_grow_threshold(capacity$2), head: undefined, tail: undefined };
 }
-function moonbitlang$core$array$$Array$each$103$(self, f) {
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      return;
-    }
-  }
+function moonbitlang$core$builtin$$Map$new$103$(capacity) {
+  const capacity$2 = moonbitlang$core$builtin$$power_2_above(8, capacity);
+  return { entries: $make_array_len_and_init(capacity$2, undefined), list: $make_array_len_and_init(capacity$2, { prev: undefined, next: undefined }), size: 0, capacity: capacity$2, capacity_mask: capacity$2 - 1 | 0, growAt: moonbitlang$core$builtin$$calc_grow_threshold(capacity$2), head: undefined, tail: undefined };
 }
-function moonbitlang$core$array$$Array$each$104$(self, f) {
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      return;
-    }
-  }
+function moonbitlang$core$builtin$$Map$new$104$(capacity) {
+  const capacity$2 = moonbitlang$core$builtin$$power_2_above(8, capacity);
+  return { entries: $make_array_len_and_init(capacity$2, undefined), list: $make_array_len_and_init(capacity$2, { prev: undefined, next: undefined }), size: 0, capacity: capacity$2, capacity_mask: capacity$2 - 1 | 0, growAt: moonbitlang$core$builtin$$calc_grow_threshold(capacity$2), head: undefined, tail: undefined };
 }
 function moonbitlang$core$array$$Array$each$105$(self, f) {
   const _len = self.length;
@@ -5231,7 +5087,142 @@ function moonbitlang$core$array$$Array$each$107$(self, f) {
     }
   }
 }
+function moonbitlang$core$array$$Array$each$108$(self, f) {
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      return;
+    }
+  }
+}
+function moonbitlang$core$array$$Array$each$109$(self, f) {
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      return;
+    }
+  }
+}
+function moonbitlang$core$array$$Array$each$110$(self, f) {
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      return;
+    }
+  }
+}
+function moonbitlang$core$array$$Array$each$111$(self, f) {
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      return;
+    }
+  }
+}
+function moonbitlang$core$array$$Array$each$112$(self, f) {
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      return;
+    }
+  }
+}
 function moonbitlang$core$builtin$$Map$add_entry_to_tail$99$(self, entry) {
+  const _bind = self.tail;
+  if (_bind === undefined) {
+    self.head = entry;
+    self.tail = entry;
+    return;
+  } else {
+    const _Some = _bind;
+    const _x = _Some;
+    self.list[_x.idx].next = entry;
+    self.list[entry.idx].prev = _x;
+    self.tail = entry;
+    return;
+  }
+}
+function moonbitlang$core$builtin$$Map$add_entry_to_tail$98$(self, entry) {
+  const _bind = self.tail;
+  if (_bind === undefined) {
+    self.head = entry;
+    self.tail = entry;
+    return;
+  } else {
+    const _Some = _bind;
+    const _x = _Some;
+    self.list[_x.idx].next = entry;
+    self.list[entry.idx].prev = _x;
+    self.tail = entry;
+    return;
+  }
+}
+function moonbitlang$core$builtin$$Map$add_entry_to_tail$102$(self, entry) {
+  const _bind = self.tail;
+  if (_bind === undefined) {
+    self.head = entry;
+    self.tail = entry;
+    return;
+  } else {
+    const _Some = _bind;
+    const _x = _Some;
+    self.list[_x.idx].next = entry;
+    self.list[entry.idx].prev = _x;
+    self.tail = entry;
+    return;
+  }
+}
+function moonbitlang$core$builtin$$Map$add_entry_to_tail$103$(self, entry) {
+  const _bind = self.tail;
+  if (_bind === undefined) {
+    self.head = entry;
+    self.tail = entry;
+    return;
+  } else {
+    const _Some = _bind;
+    const _x = _Some;
+    self.list[_x.idx].next = entry;
+    self.list[entry.idx].prev = _x;
+    self.tail = entry;
+    return;
+  }
+}
+function moonbitlang$core$builtin$$Map$add_entry_to_tail$104$(self, entry) {
   const _bind = self.tail;
   if (_bind === undefined) {
     self.head = entry;
@@ -5261,37 +5252,7 @@ function moonbitlang$core$builtin$$Map$add_entry_to_tail$101$(self, entry) {
     return;
   }
 }
-function moonbitlang$core$builtin$$Map$add_entry_to_tail$97$(self, entry) {
-  const _bind = self.tail;
-  if (_bind === undefined) {
-    self.head = entry;
-    self.tail = entry;
-    return;
-  } else {
-    const _Some = _bind;
-    const _x = _Some;
-    self.list[_x.idx].next = entry;
-    self.list[entry.idx].prev = _x;
-    self.tail = entry;
-    return;
-  }
-}
 function moonbitlang$core$builtin$$Map$add_entry_to_tail$100$(self, entry) {
-  const _bind = self.tail;
-  if (_bind === undefined) {
-    self.head = entry;
-    self.tail = entry;
-    return;
-  } else {
-    const _Some = _bind;
-    const _x = _Some;
-    self.list[_x.idx].next = entry;
-    self.list[entry.idx].prev = _x;
-    self.tail = entry;
-    return;
-  }
-}
-function moonbitlang$core$builtin$$Map$add_entry_to_tail$98$(self, entry) {
   const _bind = self.tail;
   if (_bind === undefined) {
     self.head = entry;
@@ -5325,7 +5286,7 @@ function moonbitlang$core$builtin$$Map$set$98$(self, key, value) {
   if (self.size >= self.growAt) {
     moonbitlang$core$builtin$$Map$grow$98$(self);
   }
-  const hash = moonbitlang$core$builtin$$Hash$hash$108$(key);
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
   const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
   const list_node = { prev: undefined, next: undefined };
   let _tmp = 0;
@@ -5376,176 +5337,11 @@ function moonbitlang$core$builtin$$Map$set$98$(self, key, value) {
     }
   }
 }
-function moonbitlang$core$builtin$$Map$set$100$(self, key, value) {
-  if (self.size >= self.growAt) {
-    moonbitlang$core$builtin$$Map$grow$100$(self);
-  }
-  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
-  const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
-  const list_node = { prev: undefined, next: undefined };
-  let _tmp = 0;
-  let _tmp$2 = hash & self.capacity_mask;
-  let _tmp$3 = insert_entry;
-  let _tmp$4 = list_node;
-  while (true) {
-    const _param = _tmp;
-    const _param$2 = _tmp$2;
-    const _param$3 = _tmp$3;
-    const _param$4 = _tmp$4;
-    const _bind = self.entries[_param$2];
-    if (_bind === undefined) {
-      self.entries[_param$2] = _param$3;
-      self.list[_param$2] = _param$4;
-      _param$3.idx = _param$2;
-      moonbitlang$core$builtin$$Map$add_entry_to_tail$100$(self, insert_entry);
-      self.size = self.size + 1 | 0;
-      return;
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      const curr_node = self.list[_x.idx];
-      if (_x.hash === _param$3.hash && _x.key === _param$3.key) {
-        _x.value = _param$3.value;
-        break;
-      }
-      if (_param$3.psl > _x.psl) {
-        self.entries[_param$2] = _param$3;
-        self.list[_param$2] = _param$4;
-        _param$3.idx = _param$2;
-        _x.psl = _x.psl + 1 | 0;
-        const _tmp$5 = _param + 1 | 0;
-        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
-        _tmp = _tmp$5;
-        _tmp$2 = _tmp$6;
-        _tmp$3 = _x;
-        _tmp$4 = curr_node;
-        continue;
-      } else {
-        _param$3.psl = _param$3.psl + 1 | 0;
-        const _tmp$5 = _param + 1 | 0;
-        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
-        _tmp = _tmp$5;
-        _tmp$2 = _tmp$6;
-        continue;
-      }
-    }
-  }
-}
-function moonbitlang$core$builtin$$Map$set$97$(self, key, value) {
-  if (self.size >= self.growAt) {
-    moonbitlang$core$builtin$$Map$grow$97$(self);
-  }
-  const hash = moonbitlang$core$builtin$$Hash$hash$108$(key);
-  const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
-  const list_node = { prev: undefined, next: undefined };
-  let _tmp = 0;
-  let _tmp$2 = hash & self.capacity_mask;
-  let _tmp$3 = insert_entry;
-  let _tmp$4 = list_node;
-  while (true) {
-    const _param = _tmp;
-    const _param$2 = _tmp$2;
-    const _param$3 = _tmp$3;
-    const _param$4 = _tmp$4;
-    const _bind = self.entries[_param$2];
-    if (_bind === undefined) {
-      self.entries[_param$2] = _param$3;
-      self.list[_param$2] = _param$4;
-      _param$3.idx = _param$2;
-      moonbitlang$core$builtin$$Map$add_entry_to_tail$97$(self, insert_entry);
-      self.size = self.size + 1 | 0;
-      return;
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      const curr_node = self.list[_x.idx];
-      if (_x.hash === _param$3.hash && _x.key === _param$3.key) {
-        _x.value = _param$3.value;
-        break;
-      }
-      if (_param$3.psl > _x.psl) {
-        self.entries[_param$2] = _param$3;
-        self.list[_param$2] = _param$4;
-        _param$3.idx = _param$2;
-        _x.psl = _x.psl + 1 | 0;
-        const _tmp$5 = _param + 1 | 0;
-        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
-        _tmp = _tmp$5;
-        _tmp$2 = _tmp$6;
-        _tmp$3 = _x;
-        _tmp$4 = curr_node;
-        continue;
-      } else {
-        _param$3.psl = _param$3.psl + 1 | 0;
-        const _tmp$5 = _param + 1 | 0;
-        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
-        _tmp = _tmp$5;
-        _tmp$2 = _tmp$6;
-        continue;
-      }
-    }
-  }
-}
-function moonbitlang$core$builtin$$Map$set$101$(self, key, value) {
-  if (self.size >= self.growAt) {
-    moonbitlang$core$builtin$$Map$grow$101$(self);
-  }
-  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
-  const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
-  const list_node = { prev: undefined, next: undefined };
-  let _tmp = 0;
-  let _tmp$2 = hash & self.capacity_mask;
-  let _tmp$3 = insert_entry;
-  let _tmp$4 = list_node;
-  while (true) {
-    const _param = _tmp;
-    const _param$2 = _tmp$2;
-    const _param$3 = _tmp$3;
-    const _param$4 = _tmp$4;
-    const _bind = self.entries[_param$2];
-    if (_bind === undefined) {
-      self.entries[_param$2] = _param$3;
-      self.list[_param$2] = _param$4;
-      _param$3.idx = _param$2;
-      moonbitlang$core$builtin$$Map$add_entry_to_tail$101$(self, insert_entry);
-      self.size = self.size + 1 | 0;
-      return;
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      const curr_node = self.list[_x.idx];
-      if (_x.hash === _param$3.hash && _x.key === _param$3.key) {
-        _x.value = _param$3.value;
-        break;
-      }
-      if (_param$3.psl > _x.psl) {
-        self.entries[_param$2] = _param$3;
-        self.list[_param$2] = _param$4;
-        _param$3.idx = _param$2;
-        _x.psl = _x.psl + 1 | 0;
-        const _tmp$5 = _param + 1 | 0;
-        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
-        _tmp = _tmp$5;
-        _tmp$2 = _tmp$6;
-        _tmp$3 = _x;
-        _tmp$4 = curr_node;
-        continue;
-      } else {
-        _param$3.psl = _param$3.psl + 1 | 0;
-        const _tmp$5 = _param + 1 | 0;
-        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
-        _tmp = _tmp$5;
-        _tmp$2 = _tmp$6;
-        continue;
-      }
-    }
-  }
-}
 function moonbitlang$core$builtin$$Map$set$99$(self, key, value) {
   if (self.size >= self.growAt) {
     moonbitlang$core$builtin$$Map$grow$99$(self);
   }
-  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
   const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
   const list_node = { prev: undefined, next: undefined };
   let _tmp = 0;
@@ -5600,7 +5396,7 @@ function moonbitlang$core$builtin$$Map$set$74$(self, key, value) {
   if (self.size >= self.growAt) {
     moonbitlang$core$builtin$$Map$grow$74$(self);
   }
-  const hash = moonbitlang$core$builtin$$Hash$hash$108$(key);
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
   const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
   const list_node = { prev: undefined, next: undefined };
   let _tmp = 0;
@@ -5618,6 +5414,281 @@ function moonbitlang$core$builtin$$Map$set$74$(self, key, value) {
       self.list[_param$2] = _param$4;
       _param$3.idx = _param$2;
       moonbitlang$core$builtin$$Map$add_entry_to_tail$74$(self, insert_entry);
+      self.size = self.size + 1 | 0;
+      return;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      const curr_node = self.list[_x.idx];
+      if (_x.hash === _param$3.hash && _x.key === _param$3.key) {
+        _x.value = _param$3.value;
+        break;
+      }
+      if (_param$3.psl > _x.psl) {
+        self.entries[_param$2] = _param$3;
+        self.list[_param$2] = _param$4;
+        _param$3.idx = _param$2;
+        _x.psl = _x.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        _tmp$3 = _x;
+        _tmp$4 = curr_node;
+        continue;
+      } else {
+        _param$3.psl = _param$3.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        continue;
+      }
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$set$100$(self, key, value) {
+  if (self.size >= self.growAt) {
+    moonbitlang$core$builtin$$Map$grow$100$(self);
+  }
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
+  const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
+  const list_node = { prev: undefined, next: undefined };
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  let _tmp$3 = insert_entry;
+  let _tmp$4 = list_node;
+  while (true) {
+    const _param = _tmp;
+    const _param$2 = _tmp$2;
+    const _param$3 = _tmp$3;
+    const _param$4 = _tmp$4;
+    const _bind = self.entries[_param$2];
+    if (_bind === undefined) {
+      self.entries[_param$2] = _param$3;
+      self.list[_param$2] = _param$4;
+      _param$3.idx = _param$2;
+      moonbitlang$core$builtin$$Map$add_entry_to_tail$100$(self, insert_entry);
+      self.size = self.size + 1 | 0;
+      return;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      const curr_node = self.list[_x.idx];
+      if (_x.hash === _param$3.hash && _x.key === _param$3.key) {
+        _x.value = _param$3.value;
+        break;
+      }
+      if (_param$3.psl > _x.psl) {
+        self.entries[_param$2] = _param$3;
+        self.list[_param$2] = _param$4;
+        _param$3.idx = _param$2;
+        _x.psl = _x.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        _tmp$3 = _x;
+        _tmp$4 = curr_node;
+        continue;
+      } else {
+        _param$3.psl = _param$3.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        continue;
+      }
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$set$101$(self, key, value) {
+  if (self.size >= self.growAt) {
+    moonbitlang$core$builtin$$Map$grow$101$(self);
+  }
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
+  const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
+  const list_node = { prev: undefined, next: undefined };
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  let _tmp$3 = insert_entry;
+  let _tmp$4 = list_node;
+  while (true) {
+    const _param = _tmp;
+    const _param$2 = _tmp$2;
+    const _param$3 = _tmp$3;
+    const _param$4 = _tmp$4;
+    const _bind = self.entries[_param$2];
+    if (_bind === undefined) {
+      self.entries[_param$2] = _param$3;
+      self.list[_param$2] = _param$4;
+      _param$3.idx = _param$2;
+      moonbitlang$core$builtin$$Map$add_entry_to_tail$101$(self, insert_entry);
+      self.size = self.size + 1 | 0;
+      return;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      const curr_node = self.list[_x.idx];
+      if (_x.hash === _param$3.hash && _x.key === _param$3.key) {
+        _x.value = _param$3.value;
+        break;
+      }
+      if (_param$3.psl > _x.psl) {
+        self.entries[_param$2] = _param$3;
+        self.list[_param$2] = _param$4;
+        _param$3.idx = _param$2;
+        _x.psl = _x.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        _tmp$3 = _x;
+        _tmp$4 = curr_node;
+        continue;
+      } else {
+        _param$3.psl = _param$3.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        continue;
+      }
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$set$104$(self, key, value) {
+  if (self.size >= self.growAt) {
+    moonbitlang$core$builtin$$Map$grow$104$(self);
+  }
+  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+  const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
+  const list_node = { prev: undefined, next: undefined };
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  let _tmp$3 = insert_entry;
+  let _tmp$4 = list_node;
+  while (true) {
+    const _param = _tmp;
+    const _param$2 = _tmp$2;
+    const _param$3 = _tmp$3;
+    const _param$4 = _tmp$4;
+    const _bind = self.entries[_param$2];
+    if (_bind === undefined) {
+      self.entries[_param$2] = _param$3;
+      self.list[_param$2] = _param$4;
+      _param$3.idx = _param$2;
+      moonbitlang$core$builtin$$Map$add_entry_to_tail$104$(self, insert_entry);
+      self.size = self.size + 1 | 0;
+      return;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      const curr_node = self.list[_x.idx];
+      if (_x.hash === _param$3.hash && _x.key === _param$3.key) {
+        _x.value = _param$3.value;
+        break;
+      }
+      if (_param$3.psl > _x.psl) {
+        self.entries[_param$2] = _param$3;
+        self.list[_param$2] = _param$4;
+        _param$3.idx = _param$2;
+        _x.psl = _x.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        _tmp$3 = _x;
+        _tmp$4 = curr_node;
+        continue;
+      } else {
+        _param$3.psl = _param$3.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        continue;
+      }
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$set$103$(self, key, value) {
+  if (self.size >= self.growAt) {
+    moonbitlang$core$builtin$$Map$grow$103$(self);
+  }
+  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+  const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
+  const list_node = { prev: undefined, next: undefined };
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  let _tmp$3 = insert_entry;
+  let _tmp$4 = list_node;
+  while (true) {
+    const _param = _tmp;
+    const _param$2 = _tmp$2;
+    const _param$3 = _tmp$3;
+    const _param$4 = _tmp$4;
+    const _bind = self.entries[_param$2];
+    if (_bind === undefined) {
+      self.entries[_param$2] = _param$3;
+      self.list[_param$2] = _param$4;
+      _param$3.idx = _param$2;
+      moonbitlang$core$builtin$$Map$add_entry_to_tail$103$(self, insert_entry);
+      self.size = self.size + 1 | 0;
+      return;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      const curr_node = self.list[_x.idx];
+      if (_x.hash === _param$3.hash && _x.key === _param$3.key) {
+        _x.value = _param$3.value;
+        break;
+      }
+      if (_param$3.psl > _x.psl) {
+        self.entries[_param$2] = _param$3;
+        self.list[_param$2] = _param$4;
+        _param$3.idx = _param$2;
+        _x.psl = _x.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        _tmp$3 = _x;
+        _tmp$4 = curr_node;
+        continue;
+      } else {
+        _param$3.psl = _param$3.psl + 1 | 0;
+        const _tmp$5 = _param + 1 | 0;
+        const _tmp$6 = _param$2 + 1 & self.capacity_mask;
+        _tmp = _tmp$5;
+        _tmp$2 = _tmp$6;
+        continue;
+      }
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$set$102$(self, key, value) {
+  if (self.size >= self.growAt) {
+    moonbitlang$core$builtin$$Map$grow$102$(self);
+  }
+  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+  const insert_entry = { idx: -1, psl: 0, hash: hash, key: key, value: value };
+  const list_node = { prev: undefined, next: undefined };
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  let _tmp$3 = insert_entry;
+  let _tmp$4 = list_node;
+  while (true) {
+    const _param = _tmp;
+    const _param$2 = _tmp$2;
+    const _param$3 = _tmp$3;
+    const _param$4 = _tmp$4;
+    const _bind = self.entries[_param$2];
+    if (_bind === undefined) {
+      self.entries[_param$2] = _param$3;
+      self.list[_param$2] = _param$4;
+      _param$3.idx = _param$2;
+      moonbitlang$core$builtin$$Map$add_entry_to_tail$102$(self, insert_entry);
       self.size = self.size + 1 | 0;
       return;
     } else {
@@ -5680,6 +5751,122 @@ function moonbitlang$core$builtin$$Map$grow$99$(self) {
     }
   }
 }
+function moonbitlang$core$builtin$$Map$grow$98$(self) {
+  const old_head = self.head;
+  const old_list = self.list;
+  const new_capacity = self.capacity << 1;
+  self.entries = $make_array_len_and_init(new_capacity, undefined);
+  self.list = $make_array_len_and_init(new_capacity, { prev: undefined, next: undefined });
+  self.capacity = new_capacity;
+  self.capacity_mask = new_capacity - 1 | 0;
+  self.growAt = moonbitlang$core$builtin$$calc_grow_threshold(self.capacity);
+  self.size = 0;
+  self.head = undefined;
+  self.tail = undefined;
+  let _tmp = old_head;
+  while (true) {
+    const _param = _tmp;
+    if (_param === undefined) {
+      return;
+    } else {
+      const _Some = _param;
+      const _x = _Some;
+      const _x$2 = _x.idx;
+      const _x$3 = _x.key;
+      const _x$4 = _x.value;
+      moonbitlang$core$builtin$$Map$set$98$(self, _x$3, _x$4);
+      _tmp = old_list[_x$2].next;
+      continue;
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$grow$102$(self) {
+  const old_head = self.head;
+  const old_list = self.list;
+  const new_capacity = self.capacity << 1;
+  self.entries = $make_array_len_and_init(new_capacity, undefined);
+  self.list = $make_array_len_and_init(new_capacity, { prev: undefined, next: undefined });
+  self.capacity = new_capacity;
+  self.capacity_mask = new_capacity - 1 | 0;
+  self.growAt = moonbitlang$core$builtin$$calc_grow_threshold(self.capacity);
+  self.size = 0;
+  self.head = undefined;
+  self.tail = undefined;
+  let _tmp = old_head;
+  while (true) {
+    const _param = _tmp;
+    if (_param === undefined) {
+      return;
+    } else {
+      const _Some = _param;
+      const _x = _Some;
+      const _x$2 = _x.idx;
+      const _x$3 = _x.key;
+      const _x$4 = _x.value;
+      moonbitlang$core$builtin$$Map$set$102$(self, _x$3, _x$4);
+      _tmp = old_list[_x$2].next;
+      continue;
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$grow$103$(self) {
+  const old_head = self.head;
+  const old_list = self.list;
+  const new_capacity = self.capacity << 1;
+  self.entries = $make_array_len_and_init(new_capacity, undefined);
+  self.list = $make_array_len_and_init(new_capacity, { prev: undefined, next: undefined });
+  self.capacity = new_capacity;
+  self.capacity_mask = new_capacity - 1 | 0;
+  self.growAt = moonbitlang$core$builtin$$calc_grow_threshold(self.capacity);
+  self.size = 0;
+  self.head = undefined;
+  self.tail = undefined;
+  let _tmp = old_head;
+  while (true) {
+    const _param = _tmp;
+    if (_param === undefined) {
+      return;
+    } else {
+      const _Some = _param;
+      const _x = _Some;
+      const _x$2 = _x.idx;
+      const _x$3 = _x.key;
+      const _x$4 = _x.value;
+      moonbitlang$core$builtin$$Map$set$103$(self, _x$3, _x$4);
+      _tmp = old_list[_x$2].next;
+      continue;
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$grow$104$(self) {
+  const old_head = self.head;
+  const old_list = self.list;
+  const new_capacity = self.capacity << 1;
+  self.entries = $make_array_len_and_init(new_capacity, undefined);
+  self.list = $make_array_len_and_init(new_capacity, { prev: undefined, next: undefined });
+  self.capacity = new_capacity;
+  self.capacity_mask = new_capacity - 1 | 0;
+  self.growAt = moonbitlang$core$builtin$$calc_grow_threshold(self.capacity);
+  self.size = 0;
+  self.head = undefined;
+  self.tail = undefined;
+  let _tmp = old_head;
+  while (true) {
+    const _param = _tmp;
+    if (_param === undefined) {
+      return;
+    } else {
+      const _Some = _param;
+      const _x = _Some;
+      const _x$2 = _x.idx;
+      const _x$3 = _x.key;
+      const _x$4 = _x.value;
+      moonbitlang$core$builtin$$Map$set$104$(self, _x$3, _x$4);
+      _tmp = old_list[_x$2].next;
+      continue;
+    }
+  }
+}
 function moonbitlang$core$builtin$$Map$grow$101$(self) {
   const old_head = self.head;
   const old_list = self.list;
@@ -5704,35 +5891,6 @@ function moonbitlang$core$builtin$$Map$grow$101$(self) {
       const _x$3 = _x.key;
       const _x$4 = _x.value;
       moonbitlang$core$builtin$$Map$set$101$(self, _x$3, _x$4);
-      _tmp = old_list[_x$2].next;
-      continue;
-    }
-  }
-}
-function moonbitlang$core$builtin$$Map$grow$97$(self) {
-  const old_head = self.head;
-  const old_list = self.list;
-  const new_capacity = self.capacity << 1;
-  self.entries = $make_array_len_and_init(new_capacity, undefined);
-  self.list = $make_array_len_and_init(new_capacity, { prev: undefined, next: undefined });
-  self.capacity = new_capacity;
-  self.capacity_mask = new_capacity - 1 | 0;
-  self.growAt = moonbitlang$core$builtin$$calc_grow_threshold(self.capacity);
-  self.size = 0;
-  self.head = undefined;
-  self.tail = undefined;
-  let _tmp = old_head;
-  while (true) {
-    const _param = _tmp;
-    if (_param === undefined) {
-      return;
-    } else {
-      const _Some = _param;
-      const _x = _Some;
-      const _x$2 = _x.idx;
-      const _x$3 = _x.key;
-      const _x$4 = _x.value;
-      moonbitlang$core$builtin$$Map$set$97$(self, _x$3, _x$4);
       _tmp = old_list[_x$2].next;
       continue;
     }
@@ -5767,35 +5925,6 @@ function moonbitlang$core$builtin$$Map$grow$100$(self) {
     }
   }
 }
-function moonbitlang$core$builtin$$Map$grow$98$(self) {
-  const old_head = self.head;
-  const old_list = self.list;
-  const new_capacity = self.capacity << 1;
-  self.entries = $make_array_len_and_init(new_capacity, undefined);
-  self.list = $make_array_len_and_init(new_capacity, { prev: undefined, next: undefined });
-  self.capacity = new_capacity;
-  self.capacity_mask = new_capacity - 1 | 0;
-  self.growAt = moonbitlang$core$builtin$$calc_grow_threshold(self.capacity);
-  self.size = 0;
-  self.head = undefined;
-  self.tail = undefined;
-  let _tmp = old_head;
-  while (true) {
-    const _param = _tmp;
-    if (_param === undefined) {
-      return;
-    } else {
-      const _Some = _param;
-      const _x = _Some;
-      const _x$2 = _x.idx;
-      const _x$3 = _x.key;
-      const _x$4 = _x.value;
-      moonbitlang$core$builtin$$Map$set$98$(self, _x$3, _x$4);
-      _tmp = old_list[_x$2].next;
-      continue;
-    }
-  }
-}
 function moonbitlang$core$builtin$$Map$grow$74$(self) {
   const old_head = self.head;
   const old_list = self.list;
@@ -5825,65 +5954,85 @@ function moonbitlang$core$builtin$$Map$grow$74$(self) {
     }
   }
 }
-function moonbitlang$core$builtin$$Map$from_array$101$(arr) {
-  const m = moonbitlang$core$builtin$$Map$new$101$(arr.length);
-  moonbitlang$core$array$$Array$each$107$(arr, (e) => {
-    moonbitlang$core$builtin$$Map$set$101$(m, e._0, e._1);
-  });
-  return m;
-}
-function moonbitlang$core$builtin$$Map$from_array$100$(arr) {
-  const m = moonbitlang$core$builtin$$Map$new$100$(arr.length);
-  moonbitlang$core$array$$Array$each$106$(arr, (e) => {
-    moonbitlang$core$builtin$$Map$set$100$(m, e._0, e._1);
-  });
-  return m;
-}
 function moonbitlang$core$builtin$$Map$from_array$99$(arr) {
   const m = moonbitlang$core$builtin$$Map$new$99$(arr.length);
-  moonbitlang$core$array$$Array$each$105$(arr, (e) => {
+  moonbitlang$core$array$$Array$each$107$(arr, (e) => {
     moonbitlang$core$builtin$$Map$set$99$(m, e._0, e._1);
   });
   return m;
 }
 function moonbitlang$core$builtin$$Map$from_array$98$(arr) {
   const m = moonbitlang$core$builtin$$Map$new$98$(arr.length);
-  moonbitlang$core$array$$Array$each$104$(arr, (e) => {
+  moonbitlang$core$array$$Array$each$106$(arr, (e) => {
     moonbitlang$core$builtin$$Map$set$98$(m, e._0, e._1);
-  });
-  return m;
-}
-function moonbitlang$core$builtin$$Map$from_array$97$(arr) {
-  const m = moonbitlang$core$builtin$$Map$new$97$(arr.length);
-  moonbitlang$core$array$$Array$each$103$(arr, (e) => {
-    moonbitlang$core$builtin$$Map$set$97$(m, e._0, e._1);
   });
   return m;
 }
 function moonbitlang$core$builtin$$Map$from_array$74$(arr) {
   const m = moonbitlang$core$builtin$$Map$new$74$(arr.length);
-  moonbitlang$core$array$$Array$each$102$(arr, (e) => {
+  moonbitlang$core$array$$Array$each$105$(arr, (e) => {
     moonbitlang$core$builtin$$Map$set$74$(m, e._0, e._1);
   });
   return m;
 }
-function moonbitlang$core$builtin$$Map$op_set$98$(self, key, value) {
-  moonbitlang$core$builtin$$Map$set$98$(self, key, value);
+function moonbitlang$core$builtin$$Map$from_array$104$(arr) {
+  const m = moonbitlang$core$builtin$$Map$new$104$(arr.length);
+  moonbitlang$core$array$$Array$each$112$(arr, (e) => {
+    moonbitlang$core$builtin$$Map$set$104$(m, e._0, e._1);
+  });
+  return m;
+}
+function moonbitlang$core$builtin$$Map$from_array$103$(arr) {
+  const m = moonbitlang$core$builtin$$Map$new$103$(arr.length);
+  moonbitlang$core$array$$Array$each$111$(arr, (e) => {
+    moonbitlang$core$builtin$$Map$set$103$(m, e._0, e._1);
+  });
+  return m;
+}
+function moonbitlang$core$builtin$$Map$from_array$102$(arr) {
+  const m = moonbitlang$core$builtin$$Map$new$102$(arr.length);
+  moonbitlang$core$array$$Array$each$110$(arr, (e) => {
+    moonbitlang$core$builtin$$Map$set$102$(m, e._0, e._1);
+  });
+  return m;
+}
+function moonbitlang$core$builtin$$Map$from_array$101$(arr) {
+  const m = moonbitlang$core$builtin$$Map$new$101$(arr.length);
+  moonbitlang$core$array$$Array$each$109$(arr, (e) => {
+    moonbitlang$core$builtin$$Map$set$101$(m, e._0, e._1);
+  });
+  return m;
+}
+function moonbitlang$core$builtin$$Map$from_array$100$(arr) {
+  const m = moonbitlang$core$builtin$$Map$new$100$(arr.length);
+  moonbitlang$core$array$$Array$each$108$(arr, (e) => {
+    moonbitlang$core$builtin$$Map$set$100$(m, e._0, e._1);
+  });
+  return m;
 }
 function moonbitlang$core$builtin$$Map$op_set$99$(self, key, value) {
   moonbitlang$core$builtin$$Map$set$99$(self, key, value);
 }
+function moonbitlang$core$builtin$$Map$op_set$98$(self, key, value) {
+  moonbitlang$core$builtin$$Map$set$98$(self, key, value);
+}
+function moonbitlang$core$builtin$$Map$op_set$102$(self, key, value) {
+  moonbitlang$core$builtin$$Map$set$102$(self, key, value);
+}
+function moonbitlang$core$builtin$$Map$op_set$103$(self, key, value) {
+  moonbitlang$core$builtin$$Map$set$103$(self, key, value);
+}
+function moonbitlang$core$builtin$$Map$op_set$104$(self, key, value) {
+  moonbitlang$core$builtin$$Map$set$104$(self, key, value);
+}
 function moonbitlang$core$builtin$$Map$op_set$101$(self, key, value) {
   moonbitlang$core$builtin$$Map$set$101$(self, key, value);
-}
-function moonbitlang$core$builtin$$Map$op_set$97$(self, key, value) {
-  moonbitlang$core$builtin$$Map$set$97$(self, key, value);
 }
 function moonbitlang$core$builtin$$Map$op_set$100$(self, key, value) {
   moonbitlang$core$builtin$$Map$set$100$(self, key, value);
 }
-function moonbitlang$core$builtin$$Map$get$101$(self, key) {
-  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+function moonbitlang$core$builtin$$Map$get$98$(self, key) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
   let _tmp = 0;
   let _tmp$2 = hash & self.capacity_mask;
   while (true) {
@@ -5910,7 +6059,115 @@ function moonbitlang$core$builtin$$Map$get$101$(self, key) {
   }
 }
 function moonbitlang$core$builtin$$Map$get$99$(self, key) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  while (true) {
+    const i = _tmp;
+    const idx = _tmp$2;
+    const _bind = self.entries[idx];
+    if (_bind === undefined) {
+      return undefined;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      if (_x.hash === hash && _x.key === key) {
+        return _x.value;
+      }
+      if (i > _x.psl) {
+        return undefined;
+      }
+      const _tmp$3 = i + 1 | 0;
+      const _tmp$4 = idx + 1 & self.capacity_mask;
+      _tmp = _tmp$3;
+      _tmp$2 = _tmp$4;
+      continue;
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$get$104$(self, key) {
   const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  while (true) {
+    const i = _tmp;
+    const idx = _tmp$2;
+    const _bind = self.entries[idx];
+    if (_bind === undefined) {
+      return undefined;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      if (_x.hash === hash && _x.key === key) {
+        return _x.value;
+      }
+      if (i > _x.psl) {
+        return undefined;
+      }
+      const _tmp$3 = i + 1 | 0;
+      const _tmp$4 = idx + 1 & self.capacity_mask;
+      _tmp = _tmp$3;
+      _tmp$2 = _tmp$4;
+      continue;
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$get$102$(self, key) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  while (true) {
+    const i = _tmp;
+    const idx = _tmp$2;
+    const _bind = self.entries[idx];
+    if (_bind === undefined) {
+      return undefined;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      if (_x.hash === hash && _x.key === key) {
+        return _x.value;
+      }
+      if (i > _x.psl) {
+        return undefined;
+      }
+      const _tmp$3 = i + 1 | 0;
+      const _tmp$4 = idx + 1 & self.capacity_mask;
+      _tmp = _tmp$3;
+      _tmp$2 = _tmp$4;
+      continue;
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$get$103$(self, key) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+  let _tmp = 0;
+  let _tmp$2 = hash & self.capacity_mask;
+  while (true) {
+    const i = _tmp;
+    const idx = _tmp$2;
+    const _bind = self.entries[idx];
+    if (_bind === undefined) {
+      return undefined;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      if (_x.hash === hash && _x.key === key) {
+        return _x.value;
+      }
+      if (i > _x.psl) {
+        return undefined;
+      }
+      const _tmp$3 = i + 1 | 0;
+      const _tmp$4 = idx + 1 & self.capacity_mask;
+      _tmp = _tmp$3;
+      _tmp$2 = _tmp$4;
+      continue;
+    }
+  }
+}
+function moonbitlang$core$builtin$$Map$get$101$(self, key) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
   let _tmp = 0;
   let _tmp$2 = hash & self.capacity_mask;
   while (true) {
@@ -5937,7 +6194,7 @@ function moonbitlang$core$builtin$$Map$get$99$(self, key) {
   }
 }
 function moonbitlang$core$builtin$$Map$get$100$(self, key) {
-  const hash = moonbitlang$core$builtin$$Hash$hash$9$(key);
+  const hash = moonbitlang$core$builtin$$Hash$hash$113$(key);
   let _tmp = 0;
   let _tmp$2 = hash & self.capacity_mask;
   while (true) {
@@ -5962,81 +6219,39 @@ function moonbitlang$core$builtin$$Map$get$100$(self, key) {
       continue;
     }
   }
-}
-function moonbitlang$core$builtin$$Map$get$98$(self, key) {
-  const hash = moonbitlang$core$builtin$$Hash$hash$108$(key);
-  let _tmp = 0;
-  let _tmp$2 = hash & self.capacity_mask;
-  while (true) {
-    const i = _tmp;
-    const idx = _tmp$2;
-    const _bind = self.entries[idx];
-    if (_bind === undefined) {
-      return undefined;
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      if (_x.hash === hash && _x.key === key) {
-        return _x.value;
-      }
-      if (i > _x.psl) {
-        return undefined;
-      }
-      const _tmp$3 = i + 1 | 0;
-      const _tmp$4 = idx + 1 & self.capacity_mask;
-      _tmp = _tmp$3;
-      _tmp$2 = _tmp$4;
-      continue;
-    }
-  }
-}
-function moonbitlang$core$builtin$$Map$get$97$(self, key) {
-  const hash = moonbitlang$core$builtin$$Hash$hash$108$(key);
-  let _tmp = 0;
-  let _tmp$2 = hash & self.capacity_mask;
-  while (true) {
-    const i = _tmp;
-    const idx = _tmp$2;
-    const _bind = self.entries[idx];
-    if (_bind === undefined) {
-      return undefined;
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      if (_x.hash === hash && _x.key === key) {
-        return _x.value;
-      }
-      if (i > _x.psl) {
-        return undefined;
-      }
-      const _tmp$3 = i + 1 | 0;
-      const _tmp$4 = idx + 1 & self.capacity_mask;
-      _tmp = _tmp$3;
-      _tmp$2 = _tmp$4;
-      continue;
-    }
-  }
-}
-function moonbitlang$core$builtin$$Map$op_get$98$(self, key) {
-  return moonbitlang$core$builtin$$Map$get$98$(self, key);
 }
 function moonbitlang$core$builtin$$Map$op_get$99$(self, key) {
   return moonbitlang$core$builtin$$Map$get$99$(self, key);
 }
-function moonbitlang$core$builtin$$Map$op_get$97$(self, key) {
-  return moonbitlang$core$builtin$$Map$get$97$(self, key);
+function moonbitlang$core$builtin$$Map$op_get$98$(self, key) {
+  return moonbitlang$core$builtin$$Map$get$98$(self, key);
+}
+function moonbitlang$core$builtin$$Map$op_get$102$(self, key) {
+  return moonbitlang$core$builtin$$Map$get$102$(self, key);
+}
+function moonbitlang$core$builtin$$Map$op_get$104$(self, key) {
+  return moonbitlang$core$builtin$$Map$get$104$(self, key);
 }
 function moonbitlang$core$builtin$$Map$op_get$101$(self, key) {
   return moonbitlang$core$builtin$$Map$get$101$(self, key);
 }
-function moonbitlang$core$builtin$$Map$get_or_init$100$(self, key, default_) {
-  const _bind = moonbitlang$core$builtin$$Map$get$100$(self, key);
+function moonbitlang$core$builtin$$Map$get_or_init$103$(self, key, default_) {
+  const _bind = moonbitlang$core$builtin$$Map$get$103$(self, key);
   if (_bind === undefined) {
     const v = default_();
-    moonbitlang$core$builtin$$Map$set$100$(self, key, v);
+    moonbitlang$core$builtin$$Map$set$103$(self, key, v);
     return v;
   } else {
     const _Some = _bind;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$15$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
     const _x = _Some;
     return _x;
   }
@@ -6059,24 +6274,6 @@ function moonbitlang$core$option$$Option$unwrap$63$(self) {
     return _x;
   }
 }
-function moonbitlang$core$option$$Option$unwrap$20$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$21$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
 function moonbitlang$core$option$$Option$unwrap$64$(self) {
   if (self === undefined) {
     return $panic();
@@ -6086,7 +6283,7 @@ function moonbitlang$core$option$$Option$unwrap$64$(self) {
     return _x;
   }
 }
-function moonbitlang$core$option$$Option$unwrap$22$(self) {
+function moonbitlang$core$option$$Option$unwrap$23$(self) {
   if (self === undefined) {
     return $panic();
   } else {
@@ -6095,79 +6292,7 @@ function moonbitlang$core$option$$Option$unwrap$22$(self) {
     return _x;
   }
 }
-function moonbitlang$core$option$$Option$unwrap$109$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$53$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$110$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$43$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$18$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$111$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$82$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$112$(self) {
-  if (self === undefined) {
-    return $panic();
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    return _x;
-  }
-}
-function moonbitlang$core$option$$Option$unwrap$113$(self) {
+function moonbitlang$core$option$$Option$unwrap$24$(self) {
   if (self === undefined) {
     return $panic();
   } else {
@@ -6185,7 +6310,106 @@ function moonbitlang$core$option$$Option$unwrap$114$(self) {
     return _x;
   }
 }
+function moonbitlang$core$option$$Option$unwrap$53$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$115$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$44$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
 function moonbitlang$core$option$$Option$unwrap$89$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$116$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$117$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$118$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$119$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$82$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$120$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$121$(self) {
+  if (self === undefined) {
+    return $panic();
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$core$option$$Option$unwrap$96$(self) {
   if (self === undefined) {
     return $panic();
   } else {
@@ -6197,26 +6421,16 @@ function moonbitlang$core$option$$Option$unwrap$89$(self) {
 function moonbitlang$core$builtin$$Map$is_empty$74$(self) {
   return self.size === 0;
 }
-function moonbitlang$core$builtin$$to_string$46$write_digits$115$(buf, num) {
-  const num2 = num / 10 | 0;
-  if (num2 !== 0) {
-    moonbitlang$core$builtin$$to_string$46$write_digits$115$(buf, num2);
-  }
-  const n = num % 10 | 0;
-  moonbitlang$core$builtin$$StringBuilder$write_char(buf, (n < 0 ? 0 - n | 0 : n) + 48 | 0);
+function moonbitlang$core$builtin$$Map$size$98$(self) {
+  return self.size;
 }
-function moonbitlang$core$int$$Int$to_string(self) {
-  const buf = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
-  if (self < 0) {
-    moonbitlang$core$builtin$$StringBuilder$write_char(buf, 45);
-  }
-  moonbitlang$core$builtin$$to_string$46$write_digits$115$(buf, self);
-  return moonbitlang$core$builtin$$StringBuilder$to_string(buf);
+function moonbitlang$core$builtin$$Map$size$99$(self) {
+  return self.size;
 }
-function moonbitlang$core$builtin$$Iter$new$43$(f) {
+function moonbitlang$core$builtin$$Iter$new$44$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$116$(f) {
+function moonbitlang$core$builtin$$Iter$new$122$(f) {
   return f;
 }
 function moonbitlang$core$builtin$$Iter$new$9$(f) {
@@ -6225,40 +6439,43 @@ function moonbitlang$core$builtin$$Iter$new$9$(f) {
 function moonbitlang$core$builtin$$Iter$new$71$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$31$(f) {
+function moonbitlang$core$builtin$$Iter$new$32$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$117$(f) {
+function moonbitlang$core$builtin$$Iter$new$123$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$42$(f) {
+function moonbitlang$core$builtin$$Iter$new$12$(f) {
+  return f;
+}
+function moonbitlang$core$builtin$$Iter$new$43$(f) {
+  return f;
+}
+function moonbitlang$core$builtin$$Iter$new$124$(f) {
   return f;
 }
 function moonbitlang$core$builtin$$Iter$new$82$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$38$(f) {
+function moonbitlang$core$builtin$$Iter$new$33$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$118$(f) {
+function moonbitlang$core$builtin$$Iter$new$39$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$14$(f) {
+function moonbitlang$core$builtin$$Iter$new$125$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$119$(f) {
+function moonbitlang$core$builtin$$Iter$new$17$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter$new$32$(f) {
-  return f;
-}
-function moonbitlang$core$builtin$$Iter$new$61$(f) {
-  return f;
-}
-function moonbitlang$core$builtin$$Iter$new$18$(f) {
+function moonbitlang$core$builtin$$Iter$new$126$(f) {
   return f;
 }
 function moonbitlang$core$builtin$$Iter$new$10$(f) {
+  return f;
+}
+function moonbitlang$core$builtin$$Iter2$new$74$(f) {
   return f;
 }
 function moonbitlang$core$builtin$$Iter2$new$55$(f) {
@@ -6270,13 +6487,7 @@ function moonbitlang$core$builtin$$Iter2$new$56$(f) {
 function moonbitlang$core$builtin$$Iter2$new$57$(f) {
   return f;
 }
-function moonbitlang$core$builtin$$Iter2$new$74$(f) {
-  return f;
-}
-function moonbitlang$core$builtin$$Iter2$new$58$(f) {
-  return f;
-}
-function moonbitlang$core$builtin$$Iter2$new$120$(f) {
+function moonbitlang$core$builtin$$Iter2$new$127$(f) {
   return f;
 }
 function moonbitlang$core$builtin$$Map$iter2$74$(self) {
@@ -6292,7 +6503,7 @@ function moonbitlang$core$builtin$$Map$iter2$74$(self) {
         const _x$2 = _x.key;
         const _x$3 = _x.value;
         const _x$4 = _x.idx;
-        if (moonbitlang$core$builtin$$Eq$op_equal$15$(yield_(_x$2, _x$3), 0)) {
+        if (moonbitlang$core$builtin$$Eq$op_equal$13$(yield_(_x$2, _x$3), 0)) {
           return 0;
         } else {
           _tmp = self.list[_x$4].next;
@@ -6302,19 +6513,19 @@ function moonbitlang$core$builtin$$Map$iter2$74$(self) {
     }
   });
 }
-function moonbitlang$core$array$$Array$new$14$(capacity) {
+function moonbitlang$core$array$$Array$new$17$(capacity) {
   return [];
-}
-function moonbitlang$core$array$$Array$push$44$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
 }
 function moonbitlang$core$array$$Array$push$45$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
-function moonbitlang$core$array$$Array$push$47$(self, value) {
+function moonbitlang$core$array$$Array$push$46$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
-function moonbitlang$core$array$$Array$push$46$(self, value) {
+function moonbitlang$core$array$$Array$push$48$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$47$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
 function moonbitlang$core$array$$Array$push$9$(self, value) {
@@ -6326,85 +6537,94 @@ function moonbitlang$core$array$$Array$push$87$(self, value) {
 function moonbitlang$core$array$$Array$push$65$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
-function moonbitlang$core$array$$Array$push$121$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$122$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$59$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$123$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$36$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$95$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$124$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$94$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$78$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$43$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$14$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$125$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$93$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$89$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$18$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$10$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$111$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$126$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$82$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
-function moonbitlang$core$array$$Array$push$127$(self, value) {
-  moonbitlang$core$builtin$$JSArray$push(self, value);
-}
 function moonbitlang$core$array$$Array$push$128$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
 function moonbitlang$core$array$$Array$push$129$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
+function moonbitlang$core$array$$Array$push$117$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$59$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
 function moonbitlang$core$array$$Array$push$130$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
-function moonbitlang$core$array$$Array$push$32$(self, value) {
+function moonbitlang$core$array$$Array$push$37$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$95$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
 function moonbitlang$core$array$$Array$push$131$(self, value) {
   moonbitlang$core$builtin$$JSArray$push(self, value);
 }
-function moonbitlang$core$array$$ArrayView$length$31$(self) {
-  return self.len;
+function moonbitlang$core$array$$Array$push$94$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$12$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$78$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$44$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$17$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$132$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$118$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$133$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$93$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$10$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$119$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$134$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$82$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$135$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$136$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$137$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$138$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$33$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$96$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
+}
+function moonbitlang$core$array$$Array$push$89$(self, value) {
+  moonbitlang$core$builtin$$JSArray$push(self, value);
 }
 function moonbitlang$core$array$$ArrayView$length$32$(self) {
+  return self.len;
+}
+function moonbitlang$core$array$$ArrayView$length$33$(self) {
   return self.len;
 }
 function moonbitlang$core$array$$ArrayView$length$78$(self) {
@@ -6413,25 +6633,14 @@ function moonbitlang$core$array$$ArrayView$length$78$(self) {
 function moonbitlang$core$array$$ArrayView$length$10$(self) {
   return self.len;
 }
-function moonbitlang$core$array$$ArrayView$op_get$31$(self, index) {
-  return index >= 0 && index < self.len ? self.buf[self.start + index | 0] : moonbitlang$core$builtin$$abort$31$(`index out of bounds: the len is from 0 to ${moonbitlang$core$int$$Int$to_string(self.len)} but the index is ${moonbitlang$core$int$$Int$to_string(index)}`);
-}
 function moonbitlang$core$array$$ArrayView$op_get$32$(self, index) {
-  return index >= 0 && index < self.len ? self.buf[self.start + index | 0] : moonbitlang$core$builtin$$abort$32$(`index out of bounds: the len is from 0 to ${moonbitlang$core$int$$Int$to_string(self.len)} but the index is ${moonbitlang$core$int$$Int$to_string(index)}`);
+  return index >= 0 && index < self.len ? self.buf[self.start + index | 0] : moonbitlang$core$builtin$$abort$32$(`index out of bounds: the len is from 0 to ${moonbitlang$core$builtin$$Show$to_string$18$(self.len)} but the index is ${moonbitlang$core$builtin$$Show$to_string$18$(index)}`);
+}
+function moonbitlang$core$array$$ArrayView$op_get$33$(self, index) {
+  return index >= 0 && index < self.len ? self.buf[self.start + index | 0] : moonbitlang$core$builtin$$abort$33$(`index out of bounds: the len is from 0 to ${moonbitlang$core$builtin$$Show$to_string$18$(self.len)} but the index is ${moonbitlang$core$builtin$$Show$to_string$18$(index)}`);
 }
 function moonbitlang$core$array$$ArrayView$op_get$78$(self, index) {
-  return index >= 0 && index < self.len ? self.buf[self.start + index | 0] : moonbitlang$core$builtin$$abort$78$(`index out of bounds: the len is from 0 to ${moonbitlang$core$int$$Int$to_string(self.len)} but the index is ${moonbitlang$core$int$$Int$to_string(index)}`);
-}
-function moonbitlang$core$array$$ArrayView$swap$31$(self, i, j) {
-  if (i >= 0 && (i < self.len && (j >= 0 && j < self.len))) {
-    const temp = self.buf[self.start + i | 0];
-    self.buf[self.start + i | 0] = self.buf[self.start + j | 0];
-    self.buf[self.start + j | 0] = temp;
-    return;
-  } else {
-    moonbitlang$core$builtin$$abort$8$(`index out of bounds: the len is from 0 to ${moonbitlang$core$int$$Int$to_string(self.len)} but the index is (${moonbitlang$core$int$$Int$to_string(i)}, ${moonbitlang$core$int$$Int$to_string(j)})`);
-    return;
-  }
+  return index >= 0 && index < self.len ? self.buf[self.start + index | 0] : moonbitlang$core$builtin$$abort$78$(`index out of bounds: the len is from 0 to ${moonbitlang$core$builtin$$Show$to_string$18$(self.len)} but the index is ${moonbitlang$core$builtin$$Show$to_string$18$(index)}`);
 }
 function moonbitlang$core$array$$ArrayView$swap$32$(self, i, j) {
   if (i >= 0 && (i < self.len && (j >= 0 && j < self.len))) {
@@ -6440,7 +6649,18 @@ function moonbitlang$core$array$$ArrayView$swap$32$(self, i, j) {
     self.buf[self.start + j | 0] = temp;
     return;
   } else {
-    moonbitlang$core$builtin$$abort$8$(`index out of bounds: the len is from 0 to ${moonbitlang$core$int$$Int$to_string(self.len)} but the index is (${moonbitlang$core$int$$Int$to_string(i)}, ${moonbitlang$core$int$$Int$to_string(j)})`);
+    moonbitlang$core$builtin$$abort$8$(`index out of bounds: the len is from 0 to ${moonbitlang$core$builtin$$Show$to_string$18$(self.len)} but the index is (${moonbitlang$core$builtin$$Show$to_string$18$(i)}, ${moonbitlang$core$builtin$$Show$to_string$18$(j)})`);
+    return;
+  }
+}
+function moonbitlang$core$array$$ArrayView$swap$33$(self, i, j) {
+  if (i >= 0 && (i < self.len && (j >= 0 && j < self.len))) {
+    const temp = self.buf[self.start + i | 0];
+    self.buf[self.start + i | 0] = self.buf[self.start + j | 0];
+    self.buf[self.start + j | 0] = temp;
+    return;
+  } else {
+    moonbitlang$core$builtin$$abort$8$(`index out of bounds: the len is from 0 to ${moonbitlang$core$builtin$$Show$to_string$18$(self.len)} but the index is (${moonbitlang$core$builtin$$Show$to_string$18$(i)}, ${moonbitlang$core$builtin$$Show$to_string$18$(j)})`);
     return;
   }
 }
@@ -6483,8 +6703,8 @@ function moonbitlang$core$array$$Array$op_as_view$61$(self, start, end) {
   const start$2 = start < 0 ? len + start | 0 : start;
   return start$2 >= 0 && (start$2 <= end$2 && end$2 <= len) ? { buf: self, start: start$2, len: end$2 - start$2 | 0 } : moonbitlang$core$builtin$$abort$79$("View index out of bounds");
 }
-function moonbitlang$core$array$$ArrayView$op_as_view$31$(self, start, end) {
-  const len = moonbitlang$core$array$$ArrayView$length$31$(self);
+function moonbitlang$core$array$$ArrayView$op_as_view$32$(self, start, end) {
+  const len = moonbitlang$core$array$$ArrayView$length$32$(self);
   let end$2;
   if (end === undefined) {
     end$2 = len;
@@ -6496,8 +6716,8 @@ function moonbitlang$core$array$$ArrayView$op_as_view$31$(self, start, end) {
   const start$2 = start < 0 ? len + start | 0 : start;
   return start$2 >= 0 && (start$2 <= end$2 && end$2 <= len) ? { buf: self.buf, start: self.start + start$2 | 0, len: end$2 - start$2 | 0 } : moonbitlang$core$builtin$$abort$76$("View index out of bounds");
 }
-function moonbitlang$core$array$$ArrayView$op_as_view$32$(self, start, end) {
-  const len = moonbitlang$core$array$$ArrayView$length$32$(self);
+function moonbitlang$core$array$$ArrayView$op_as_view$33$(self, start, end) {
+  const len = moonbitlang$core$array$$ArrayView$length$33$(self);
   let end$2;
   if (end === undefined) {
     end$2 = len;
@@ -6515,7 +6735,7 @@ function moonbitlang$core$array$$Array$unsafe_pop$65$(self) {
 function moonbitlang$core$array$$Array$unsafe_pop$78$(self) {
   return moonbitlang$core$builtin$$JSArray$pop(self);
 }
-function moonbitlang$core$array$$Array$unsafe_pop$111$(self) {
+function moonbitlang$core$array$$Array$unsafe_pop$119$(self) {
   return moonbitlang$core$builtin$$JSArray$pop(self);
 }
 function moonbitlang$core$array$$Array$unsafe_pop$82$(self) {
@@ -6527,7 +6747,7 @@ function moonbitlang$core$array$$Array$remove$82$(self, index) {
     moonbitlang$core$builtin$$JSArray$splice(self, index, 1);
     return value;
   } else {
-    return moonbitlang$core$builtin$$abort$82$(`index out of bounds: the len is from 0 to ${moonbitlang$core$int$$Int$to_string(self.length)} but the index is ${moonbitlang$core$int$$Int$to_string(index)}`);
+    return moonbitlang$core$builtin$$abort$82$(`index out of bounds: the len is from 0 to ${moonbitlang$core$builtin$$Show$to_string$18$(self.length)} but the index is ${moonbitlang$core$builtin$$Show$to_string$18$(index)}`);
   }
 }
 function moonbitlang$core$builtin$$Hasher$new(seed) {
@@ -6591,7 +6811,7 @@ function moonbitlang$core$builtin$$Hash$hash$9$(self) {
 function moonbitlang$core$builtin$$Hash$hash_combine$9$(self, hasher) {
   moonbitlang$core$builtin$$Hasher$combine_int(hasher, self);
 }
-function moonbitlang$core$array$$FixedArray$unsafe_blit$33$(dst, dst_offset, src, src_offset, len) {
+function moonbitlang$core$array$$FixedArray$unsafe_blit$34$(dst, dst_offset, src, src_offset, len) {
   if (dst === src && dst_offset < src_offset) {
     let _tmp = 0;
     while (true) {
@@ -6618,16 +6838,16 @@ function moonbitlang$core$array$$FixedArray$unsafe_blit$33$(dst, dst_offset, src
     }
   }
 }
-function moonbitlang$core$array$$FixedArray$blit_to$33$(self, dst, len, src_offset, dst_offset) {
+function moonbitlang$core$array$$FixedArray$blit_to$34$(self, dst, len, src_offset, dst_offset) {
   if ((dst_offset + len | 0) > dst.length || (src_offset + len | 0) > self.length) {
     $panic();
   }
-  moonbitlang$core$array$$FixedArray$unsafe_blit$33$(dst, dst_offset, self, src_offset, len);
+  moonbitlang$core$array$$FixedArray$unsafe_blit$34$(dst, dst_offset, self, src_offset, len);
 }
-function moonbitlang$core$array$$FixedArray$blit_to$46$src_offset$46$default$33$() {
+function moonbitlang$core$array$$FixedArray$blit_to$46$src_offset$46$default$34$() {
   return 0;
 }
-function moonbitlang$core$array$$FixedArray$blit_to$46$dst_offset$46$default$33$() {
+function moonbitlang$core$array$$FixedArray$blit_to$46$dst_offset$46$default$34$() {
   return 0;
 }
 function moonbitlang$core$builtin$$MyInt64$op_div(self, other) {
@@ -6651,10 +6871,26 @@ function moonbitlang$core$builtin$$MyInt64$op_sub(self, other) {
 function moonbitlang$core$int64$$Int64$op_sub(self, other) {
   return moonbitlang$core$builtin$$MyInt64$op_sub(self, other);
 }
+function moonbitlang$core$builtin$$to_string$46$write_digits$139$(buf, num) {
+  const num2 = num / 10 | 0;
+  if (num2 !== 0) {
+    moonbitlang$core$builtin$$to_string$46$write_digits$139$(buf, num2);
+  }
+  const n = num % 10 | 0;
+  moonbitlang$core$builtin$$StringBuilder$write_char(buf, (n < 0 ? 0 - n | 0 : n) + 48 | 0);
+}
+function moonbitlang$core$int$$Int$to_string(self) {
+  const buf = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
+  if (self < 0) {
+    moonbitlang$core$builtin$$StringBuilder$write_char(buf, 45);
+  }
+  moonbitlang$core$builtin$$to_string$46$write_digits$139$(buf, self);
+  return moonbitlang$core$builtin$$StringBuilder$to_string(buf);
+}
 function moonbitlang$core$int$$Int$to_json(self) {
   return new $64$moonbitlang$47$core$47$builtin$46$Json$Number(self + 0);
 }
-function moonbitlang$core$builtin$$escape_json_string$46$to_hex_digit$132$(i) {
+function moonbitlang$core$builtin$$escape_json_string$46$to_hex_digit$140$(i) {
   return i < 10 ? 48 + i | 0 : 97 + (i - 10 | 0) | 0;
 }
 function moonbitlang$core$builtin$$escape_json_string(str) {
@@ -6689,8 +6925,8 @@ function moonbitlang$core$builtin$$escape_json_string(str) {
           } else {
             if (code < 32) {
               moonbitlang$core$builtin$$StringBuilder$write_string(buf, "\\u00");
-              moonbitlang$core$builtin$$StringBuilder$write_char(buf, moonbitlang$core$builtin$$escape_json_string$46$to_hex_digit$132$(code / 16 | 0));
-              moonbitlang$core$builtin$$StringBuilder$write_char(buf, moonbitlang$core$builtin$$escape_json_string$46$to_hex_digit$132$(code % 16 | 0));
+              moonbitlang$core$builtin$$StringBuilder$write_char(buf, moonbitlang$core$builtin$$escape_json_string$46$to_hex_digit$140$(code / 16 | 0));
+              moonbitlang$core$builtin$$StringBuilder$write_char(buf, moonbitlang$core$builtin$$escape_json_string$46$to_hex_digit$140$(code % 16 | 0));
             } else {
               moonbitlang$core$builtin$$StringBuilder$write_char(buf, c);
             }
@@ -6707,159 +6943,6 @@ function moonbitlang$core$builtin$$escape_json_string(str) {
 }
 function moonbitlang$core$string$$String$to_json(self) {
   return new $64$moonbitlang$47$core$47$builtin$46$Json$String(moonbitlang$core$builtin$$escape_json_string(self));
-}
-function moonbitlang$core$array$$Array$map$133$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
-}
-function moonbitlang$core$array$$Array$map$134$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
-}
-function moonbitlang$core$array$$Array$map$35$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
-}
-function moonbitlang$core$array$$Array$map$135$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
-}
-function moonbitlang$core$array$$Array$map$136$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
-}
-function moonbitlang$core$array$$Array$map$137$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
-}
-function moonbitlang$core$array$$Array$map$138$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
-}
-function moonbitlang$core$array$$Array$map$139$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
-}
-function moonbitlang$core$array$$Array$map$140$(self, f) {
-  const arr = new Array(self.length);
-  const _len = self.length;
-  let _tmp = 0;
-  while (true) {
-    const _i = _tmp;
-    if (_i < _len) {
-      const v = self[_i];
-      arr[_i] = f(v);
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  return arr;
 }
 function moonbitlang$core$array$$Array$map$141$(self, f) {
   const arr = new Array(self.length);
@@ -6878,8 +6961,212 @@ function moonbitlang$core$array$$Array$map$141$(self, f) {
   }
   return arr;
 }
-function moonbitlang$core$array$$Array$to_json$128$(self) {
-  return new $64$moonbitlang$47$core$47$builtin$46$Json$Array(moonbitlang$core$array$$Array$map$136$(self, moonbitlang$core$builtin$$ToJson$to_json$128$));
+function moonbitlang$core$array$$Array$map$142$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$143$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$36$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$144$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$145$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$146$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$147$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$148$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$149$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$150$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$151$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$map$152$(self, f) {
+  const arr = new Array(self.length);
+  const _len = self.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const v = self[_i];
+      arr[_i] = f(v);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return arr;
+}
+function moonbitlang$core$array$$Array$to_json$136$(self) {
+  return new $64$moonbitlang$47$core$47$builtin$46$Json$Array(moonbitlang$core$array$$Array$map$144$(self, moonbitlang$core$builtin$$ToJson$to_json$136$));
 }
 function moonbitlang$core$array$$Array$make$9$(len, elem) {
   const arr = new Array(len);
@@ -6896,7 +7183,7 @@ function moonbitlang$core$array$$Array$make$9$(len, elem) {
   }
   return arr;
 }
-function moonbitlang$core$array$$Array$make$142$(len, elem) {
+function moonbitlang$core$array$$Array$make$153$(len, elem) {
   const arr = new Array(len);
   let _tmp = 0;
   while (true) {
@@ -6936,7 +7223,7 @@ function moonbitlang$core$array$$Array$op_set$9$(self, index, value) {
     return;
   }
 }
-function moonbitlang$core$array$$Array$op_set$142$(self, index, value) {
+function moonbitlang$core$array$$Array$op_set$153$(self, index, value) {
   const len = self.length;
   if (index >= 0 && index < len) {
     self[index] = value;
@@ -6965,22 +7252,22 @@ function moonbitlang$core$int$$Int$to_int64(self) {
 function moonbitlang$core$builtin$$Show$output$9$(self, logger) {
   logger.method_0(logger.self, moonbitlang$core$int$$Int$to_string(self));
 }
-function moonbitlang$core$builtin$$output$46$flush_segment$143$(_env, i) {
+function moonbitlang$core$builtin$$output$46$flush_segment$154$(_env, i) {
   const logger = _env._2;
-  const self = _env._1;
-  const segment_start = _env._0;
+  const segment_start = _env._1;
+  const self = _env._0;
   if (i > segment_start.val) {
     logger.method_1(logger.self, self, segment_start.val, i - segment_start.val | 0);
   }
   segment_start.val = i + 1 | 0;
 }
-function moonbitlang$core$builtin$$output$46$to_hex_digit$144$(i) {
+function moonbitlang$core$builtin$$output$46$to_hex_digit$155$(i) {
   return i < 10 ? 48 + i | 0 : 97 + (i - 10 | 0) | 0;
 }
 function moonbitlang$core$builtin$$Show$output$10$(self, logger) {
   logger.method_3(logger.self, 34);
   const segment_start = { val: 0 };
-  const _env = { _0: segment_start, _1: self, _2: logger };
+  const _env = { _0: self, _1: segment_start, _2: logger };
   let _tmp = 0;
   while (true) {
     const i = _tmp;
@@ -6996,39 +7283,39 @@ function moonbitlang$core$builtin$$Show$output$10$(self, logger) {
               break _L$2;
             }
             case 10: {
-              moonbitlang$core$builtin$$output$46$flush_segment$143$(_env, i);
+              moonbitlang$core$builtin$$output$46$flush_segment$154$(_env, i);
               logger.method_0(logger.self, "\\n");
               break;
             }
             case 13: {
-              moonbitlang$core$builtin$$output$46$flush_segment$143$(_env, i);
+              moonbitlang$core$builtin$$output$46$flush_segment$154$(_env, i);
               logger.method_0(logger.self, "\\r");
               break;
             }
             case 8: {
-              moonbitlang$core$builtin$$output$46$flush_segment$143$(_env, i);
+              moonbitlang$core$builtin$$output$46$flush_segment$154$(_env, i);
               logger.method_0(logger.self, "\\b");
               break;
             }
             case 9: {
-              moonbitlang$core$builtin$$output$46$flush_segment$143$(_env, i);
+              moonbitlang$core$builtin$$output$46$flush_segment$154$(_env, i);
               logger.method_0(logger.self, "\\t");
               break;
             }
             default: {
               const code = c;
               if (code < 32) {
-                moonbitlang$core$builtin$$output$46$flush_segment$143$(_env, i);
+                moonbitlang$core$builtin$$output$46$flush_segment$154$(_env, i);
                 logger.method_3(logger.self, 92);
                 logger.method_3(logger.self, 120);
-                logger.method_3(logger.self, moonbitlang$core$builtin$$output$46$to_hex_digit$144$(code / 16 | 0));
-                logger.method_3(logger.self, moonbitlang$core$builtin$$output$46$to_hex_digit$144$(code % 16 | 0));
+                logger.method_3(logger.self, moonbitlang$core$builtin$$output$46$to_hex_digit$155$(code / 16 | 0));
+                logger.method_3(logger.self, moonbitlang$core$builtin$$output$46$to_hex_digit$155$(code % 16 | 0));
               }
             }
           }
           break _L;
         }
-        moonbitlang$core$builtin$$output$46$flush_segment$143$(_env, i);
+        moonbitlang$core$builtin$$output$46$flush_segment$154$(_env, i);
         logger.method_3(logger.self, 92);
         logger.method_3(logger.self, c);
       }
@@ -7038,14 +7325,14 @@ function moonbitlang$core$builtin$$Show$output$10$(self, logger) {
       break;
     }
   }
-  moonbitlang$core$builtin$$output$46$flush_segment$143$(_env, self.length);
+  moonbitlang$core$builtin$$output$46$flush_segment$154$(_env, self.length);
   logger.method_3(logger.self, 34);
 }
 function moonbitlang$core$builtin$$Show$to_string$10$(self) {
   return self;
 }
-function moonbitlang$core$array$$Array$iter$31$(self) {
-  return moonbitlang$core$builtin$$Iter$new$31$((yield_) => {
+function moonbitlang$core$array$$Array$iter$32$(self) {
+  return moonbitlang$core$builtin$$Iter$new$32$((yield_) => {
     const _len = self.length;
     let _tmp = 0;
     while (true) {
@@ -7053,9 +7340,42 @@ function moonbitlang$core$array$$Array$iter$31$(self) {
       if (_i < _len) {
         const v = self[_i];
         const _bind = yield_(v);
+        let _tmp$2;
         if (_bind === 1) {
+          _tmp$2 = true;
         } else {
-          return _bind;
+          _tmp$2 = false;
+        }
+        if (_tmp$2) {
+        } else {
+          return 0;
+        }
+        _tmp = _i + 1 | 0;
+        continue;
+      } else {
+        return 1;
+      }
+    }
+  });
+}
+function moonbitlang$core$array$$Array$iter$33$(self) {
+  return moonbitlang$core$builtin$$Iter$new$33$((yield_) => {
+    const _len = self.length;
+    let _tmp = 0;
+    while (true) {
+      const _i = _tmp;
+      if (_i < _len) {
+        const v = self[_i];
+        const _bind = yield_(v);
+        let _tmp$2;
+        if (_bind === 1) {
+          _tmp$2 = true;
+        } else {
+          _tmp$2 = false;
+        }
+        if (_tmp$2) {
+        } else {
+          return 0;
         }
         _tmp = _i + 1 | 0;
         continue;
@@ -7074,72 +7394,15 @@ function moonbitlang$core$array$$Array$iter$82$(self) {
       if (_i < _len) {
         const v = self[_i];
         const _bind = yield_(v);
+        let _tmp$2;
         if (_bind === 1) {
+          _tmp$2 = true;
         } else {
-          return _bind;
+          _tmp$2 = false;
         }
-        _tmp = _i + 1 | 0;
-        continue;
-      } else {
-        return 1;
-      }
-    }
-  });
-}
-function moonbitlang$core$array$$Array$iter$61$(self) {
-  return moonbitlang$core$builtin$$Iter$new$61$((yield_) => {
-    const _len = self.length;
-    let _tmp = 0;
-    while (true) {
-      const _i = _tmp;
-      if (_i < _len) {
-        const v = self[_i];
-        const _bind = yield_(v);
-        if (_bind === 1) {
+        if (_tmp$2) {
         } else {
-          return _bind;
-        }
-        _tmp = _i + 1 | 0;
-        continue;
-      } else {
-        return 1;
-      }
-    }
-  });
-}
-function moonbitlang$core$array$$Array$iter$32$(self) {
-  return moonbitlang$core$builtin$$Iter$new$32$((yield_) => {
-    const _len = self.length;
-    let _tmp = 0;
-    while (true) {
-      const _i = _tmp;
-      if (_i < _len) {
-        const v = self[_i];
-        const _bind = yield_(v);
-        if (_bind === 1) {
-        } else {
-          return _bind;
-        }
-        _tmp = _i + 1 | 0;
-        continue;
-      } else {
-        return 1;
-      }
-    }
-  });
-}
-function moonbitlang$core$array$$Array$iter$18$(self) {
-  return moonbitlang$core$builtin$$Iter$new$18$((yield_) => {
-    const _len = self.length;
-    let _tmp = 0;
-    while (true) {
-      const _i = _tmp;
-      if (_i < _len) {
-        const v = self[_i];
-        const _bind = yield_(v);
-        if (_bind === 1) {
-        } else {
-          return _bind;
+          return 0;
         }
         _tmp = _i + 1 | 0;
         continue;
@@ -7158,9 +7421,15 @@ function moonbitlang$core$array$$Array$iter$10$(self) {
       if (_i < _len) {
         const v = self[_i];
         const _bind = yield_(v);
+        let _tmp$2;
         if (_bind === 1) {
+          _tmp$2 = true;
         } else {
-          return _bind;
+          _tmp$2 = false;
+        }
+        if (_tmp$2) {
+        } else {
+          return 0;
         }
         _tmp = _i + 1 | 0;
         continue;
@@ -7172,38 +7441,38 @@ function moonbitlang$core$array$$Array$iter$10$(self) {
 }
 function moonbitlang$core$builtin$$Hash$hash$70$(self) {
   const hasher = moonbitlang$core$builtin$$Hasher$new(moonbitlang$core$builtin$$Hasher$new$46$seed$46$default());
-  moonbitlang$core$builtin$$Hasher$combine$36$(hasher, self);
+  moonbitlang$core$builtin$$Hasher$combine$37$(hasher, self);
   return moonbitlang$core$builtin$$Hasher$finalize(hasher);
 }
-function moonbitlang$core$builtin$$Hash$hash$145$(self) {
+function moonbitlang$core$builtin$$Hash$hash$156$(self) {
   const hasher = moonbitlang$core$builtin$$Hasher$new(moonbitlang$core$builtin$$Hasher$new$46$seed$46$default());
   moonbitlang$core$builtin$$Hasher$combine$61$(hasher, self);
   return moonbitlang$core$builtin$$Hasher$finalize(hasher);
 }
-function moonbitlang$core$builtin$$Hash$hash$146$(self) {
+function moonbitlang$core$builtin$$Hash$hash$157$(self) {
   const hasher = moonbitlang$core$builtin$$Hasher$new(moonbitlang$core$builtin$$Hasher$new$46$seed$46$default());
-  moonbitlang$core$builtin$$Hasher$combine$96$(hasher, self);
+  moonbitlang$core$builtin$$Hasher$combine$97$(hasher, self);
   return moonbitlang$core$builtin$$Hasher$finalize(hasher);
 }
-function moonbitlang$core$builtin$$Hash$hash$51$(self) {
+function moonbitlang$core$builtin$$Hash$hash$52$(self) {
   const hasher = moonbitlang$core$builtin$$Hasher$new(moonbitlang$core$builtin$$Hasher$new$46$seed$46$default());
-  moonbitlang$core$builtin$$Hasher$combine$50$(hasher, self);
+  moonbitlang$core$builtin$$Hasher$combine$51$(hasher, self);
   return moonbitlang$core$builtin$$Hasher$finalize(hasher);
 }
-function moonbitlang$core$builtin$$Hash$hash$108$(self) {
+function moonbitlang$core$builtin$$Hash$hash$113$(self) {
   const hasher = moonbitlang$core$builtin$$Hasher$new(moonbitlang$core$builtin$$Hasher$new$46$seed$46$default());
   moonbitlang$core$builtin$$Hasher$combine$10$(hasher, self);
   return moonbitlang$core$builtin$$Hasher$finalize(hasher);
 }
-function moonbitlang$core$builtin$$Logger$write_sub_string$147$(self, value, start, len) {
-  moonbitlang$core$builtin$$Logger$write_substring$148$(self, value, start, len);
+function moonbitlang$core$builtin$$Logger$write_sub_string$158$(self, value, start, len) {
+  moonbitlang$core$builtin$$Logger$write_substring$159$(self, value, start, len);
 }
 function moonbitlang$core$builtin$$Logger$write_sub_string$84$(self, value, start, len) {
   moonbitlang$core$builtin$$StringBuilder$write_substring(self, value, start, len);
 }
 function moonbitlang$core$builtin$$Show$to_string$0$(self) {
   const logger = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
-  moonbitlang$core$builtin$$Show$output$149$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
+  moonbitlang$core$builtin$$Show$output$160$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
   return moonbitlang$core$builtin$$StringBuilder$to_string(logger);
 }
 function moonbitlang$core$builtin$$Show$to_string$1$(self) {
@@ -7211,19 +7480,29 @@ function moonbitlang$core$builtin$$Show$to_string$1$(self) {
   moonbitlang$core$builtin$$Show$output$11$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
   return moonbitlang$core$builtin$$StringBuilder$to_string(logger);
 }
-function moonbitlang$core$builtin$$Show$to_string$150$(self) {
+function moonbitlang$core$builtin$$Show$to_string$161$(self) {
   const logger = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
-  moonbitlang$core$builtin$$Show$output$116$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
+  moonbitlang$core$builtin$$Show$output$59$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
   return moonbitlang$core$builtin$$StringBuilder$to_string(logger);
 }
-function moonbitlang$core$builtin$$Show$to_string$151$(self) {
+function moonbitlang$core$builtin$$Show$to_string$162$(self) {
   const logger = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
-  moonbitlang$core$builtin$$Show$output$121$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
+  moonbitlang$core$builtin$$Show$output$122$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
   return moonbitlang$core$builtin$$StringBuilder$to_string(logger);
 }
-function moonbitlang$core$builtin$$Show$to_string$152$(self) {
+function moonbitlang$core$builtin$$Show$to_string$18$(self) {
   const logger = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
-  moonbitlang$core$builtin$$Show$output$153$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
+  moonbitlang$core$builtin$$Show$output$9$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
+  return moonbitlang$core$builtin$$StringBuilder$to_string(logger);
+}
+function moonbitlang$core$builtin$$Show$to_string$163$(self) {
+  const logger = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
+  moonbitlang$core$builtin$$Show$output$128$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
+  return moonbitlang$core$builtin$$StringBuilder$to_string(logger);
+}
+function moonbitlang$core$builtin$$Show$to_string$164$(self) {
+  const logger = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
+  moonbitlang$core$builtin$$Show$output$165$(self, { self: logger, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char });
   return moonbitlang$core$builtin$$StringBuilder$to_string(logger);
 }
 function moonbitlang$core$builtin$$MyInt64$op_mul(self, other) {
@@ -7283,10 +7562,6 @@ function moonbitlang$core$builtin$$Iter2$run$57$(self, f) {
   const _func = self;
   return _func(f);
 }
-function moonbitlang$core$builtin$$Iter2$run$58$(self, f) {
-  const _func = self;
-  return _func(f);
-}
 function moonbitlang$core$option$$Option$op_equal$53$(self, other) {
   if (self === undefined) {
     return other === undefined;
@@ -7302,7 +7577,7 @@ function moonbitlang$core$option$$Option$op_equal$53$(self, other) {
     }
   }
 }
-function moonbitlang$core$option$$Option$op_equal$63$(self, other) {
+function moonbitlang$core$option$$Option$op_equal$64$(self, other) {
   if (self === undefined) {
     return other === undefined;
   } else {
@@ -7317,7 +7592,7 @@ function moonbitlang$core$option$$Option$op_equal$63$(self, other) {
     }
   }
 }
-function moonbitlang$core$option$$Option$op_equal$62$(self, other) {
+function moonbitlang$core$option$$Option$op_equal$63$(self, other) {
   if (self === undefined) {
     return other === undefined;
   } else {
@@ -7332,37 +7607,7 @@ function moonbitlang$core$option$$Option$op_equal$62$(self, other) {
     }
   }
 }
-function moonbitlang$core$option$$Option$op_equal$21$(self, other) {
-  if (self === undefined) {
-    return other === undefined;
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    if (other === undefined) {
-      return false;
-    } else {
-      const _Some$2 = other;
-      const _x$2 = _Some$2;
-      return moonbitlang$core$sorted_set$$Node$op_equal$19$(_x, _x$2);
-    }
-  }
-}
-function moonbitlang$core$option$$Option$op_equal$20$(self, other) {
-  if (self === undefined) {
-    return other === undefined;
-  } else {
-    const _Some = self;
-    const _x = _Some;
-    if (other === undefined) {
-      return false;
-    } else {
-      const _Some$2 = other;
-      const _x$2 = _Some$2;
-      return moonbitlang$core$sorted_set$$Node$op_equal$10$(_x, _x$2);
-    }
-  }
-}
-function moonbitlang$core$option$$Option$op_equal$64$(self, other) {
+function moonbitlang$core$option$$Option$op_equal$62$(self, other) {
   if (self === undefined) {
     return other === undefined;
   } else {
@@ -7377,7 +7622,7 @@ function moonbitlang$core$option$$Option$op_equal$64$(self, other) {
     }
   }
 }
-function moonbitlang$core$option$$Option$op_equal$22$(self, other) {
+function moonbitlang$core$option$$Option$op_equal$24$(self, other) {
   if (self === undefined) {
     return other === undefined;
   } else {
@@ -7388,7 +7633,22 @@ function moonbitlang$core$option$$Option$op_equal$22$(self, other) {
     } else {
       const _Some$2 = other;
       const _x$2 = _Some$2;
-      return moonbitlang$core$sorted_set$$Node$op_equal$18$(_x, _x$2);
+      return moonbitlang$core$sorted_set$$Node$op_equal$22$(_x, _x$2);
+    }
+  }
+}
+function moonbitlang$core$option$$Option$op_equal$23$(self, other) {
+  if (self === undefined) {
+    return other === undefined;
+  } else {
+    const _Some = self;
+    const _x = _Some;
+    if (other === undefined) {
+      return false;
+    } else {
+      const _Some$2 = other;
+      const _x$2 = _Some$2;
+      return moonbitlang$core$sorted_set$$Node$op_equal$10$(_x, _x$2);
     }
   }
 }
@@ -7396,7 +7656,7 @@ function moonbitlang$core$array$$Array$get$61$(self, index) {
   const len = self.length;
   return index >= 0 && index < len ? self[index] : undefined;
 }
-function moonbitlang$core$array$$Array$op_equal$36$(self, other) {
+function moonbitlang$core$array$$Array$op_equal$37$(self, other) {
   const self_len = self.length;
   const other_len = other.length;
   if (self_len === other_len) {
@@ -7404,7 +7664,7 @@ function moonbitlang$core$array$$Array$op_equal$36$(self, other) {
     while (true) {
       const i = _tmp;
       if (i < self_len) {
-        if (moonbitlang$core$builtin$$Eq$op_equal$36$(self[i], other[i])) {
+        if (moonbitlang$core$builtin$$Eq$op_equal$37$(self[i], other[i])) {
         } else {
           return false;
         }
@@ -7418,7 +7678,7 @@ function moonbitlang$core$array$$Array$op_equal$36$(self, other) {
     return false;
   }
 }
-function moonbitlang$core$array$$Array$mapi$154$(self, f) {
+function moonbitlang$core$array$$Array$mapi$166$(self, f) {
   if (self.length === 0) {
     return [];
   }
@@ -7438,7 +7698,7 @@ function moonbitlang$core$array$$Array$mapi$154$(self, f) {
   }
   return arr;
 }
-function moonbitlang$core$array$$Array$mapi$155$(self, f) {
+function moonbitlang$core$array$$Array$mapi$167$(self, f) {
   if (self.length === 0) {
     return [];
   }
@@ -7464,23 +7724,20 @@ function moonbitlang$core$array$$Array$is_empty$65$(self) {
 function moonbitlang$core$array$$Array$is_empty$75$(self) {
   return self.length === 0;
 }
-function moonbitlang$core$array$$Array$is_empty$111$(self) {
+function moonbitlang$core$array$$Array$is_empty$119$(self) {
   return self.length === 0;
 }
 function moonbitlang$core$array$$Array$is_empty$82$(self) {
   return self.length === 0;
 }
-function moonbitlang$core$array$$Array$is_empty$61$(self) {
-  return self.length === 0;
-}
-function moonbitlang$core$array$$Array$contains$32$(self, value) {
+function moonbitlang$core$array$$Array$contains$33$(self, value) {
   const _len = self.length;
   let _tmp = 0;
   while (true) {
     const _i = _tmp;
     if (_i < _len) {
       const v = self[_i];
-      if (moonbitlang$core$builtin$$Eq$op_equal$32$(v, value)) {
+      if (moonbitlang$core$builtin$$Eq$op_equal$33$(v, value)) {
         return true;
       }
       _tmp = _i + 1 | 0;
@@ -7507,7 +7764,7 @@ function moonbitlang$core$array$$Array$search_by$82$(self, f) {
     }
   }
 }
-function moonbitlang$core$array$$Array$fold$156$(self, init, f) {
+function moonbitlang$core$array$$Array$fold$168$(self, init, f) {
   let _tmp = 0;
   let _tmp$2 = init;
   while (true) {
@@ -7515,7 +7772,7 @@ function moonbitlang$core$array$$Array$fold$156$(self, init, f) {
     const acc = _tmp$2;
     if (i < self.length) {
       const _tmp$3 = i + 1 | 0;
-      const _tmp$4 = f(acc, moonbitlang$core$array$$Array$op_get$32$(self, i));
+      const _tmp$4 = f(acc, moonbitlang$core$array$$Array$op_get$33$(self, i));
       _tmp = _tmp$3;
       _tmp$2 = _tmp$4;
       continue;
@@ -7524,7 +7781,7 @@ function moonbitlang$core$array$$Array$fold$156$(self, init, f) {
     }
   }
 }
-function moonbitlang$core$array$$Array$fold$157$(self, init, f) {
+function moonbitlang$core$array$$Array$fold$169$(self, init, f) {
   let _tmp = 0;
   let _tmp$2 = init;
   while (true) {
@@ -7541,7 +7798,32 @@ function moonbitlang$core$array$$Array$fold$157$(self, init, f) {
     }
   }
 }
-function moonbitlang$core$builtin$$Iter$run$14$(self, f) {
+function moonbitlang$core$array$$Array$rev_iter$124$(self) {
+  return moonbitlang$core$builtin$$Iter$new$124$((yield_) => {
+    let _tmp = self.length - 1 | 0;
+    while (true) {
+      const i = _tmp;
+      if (i >= 0) {
+        const _bind = yield_(self[i]);
+        let _tmp$2;
+        if (_bind === 1) {
+          _tmp$2 = true;
+        } else {
+          _tmp$2 = false;
+        }
+        if (_tmp$2) {
+        } else {
+          return 0;
+        }
+        _tmp = i - 1 | 0;
+        continue;
+      } else {
+        return 1;
+      }
+    }
+  });
+}
+function moonbitlang$core$builtin$$Iter$run$17$(self, f) {
   const _func = self;
   return _func(f);
 }
@@ -7549,23 +7831,11 @@ function moonbitlang$core$builtin$$Iter$run$10$(self, f) {
   const _func = self;
   return _func(f);
 }
-function moonbitlang$core$builtin$$Iter$run$38$(self, f) {
+function moonbitlang$core$builtin$$Iter$run$39$(self, f) {
   const _func = self;
   return _func(f);
 }
-function moonbitlang$core$builtin$$Iter$run$32$(self, f) {
-  const _func = self;
-  return _func(f);
-}
-function moonbitlang$core$builtin$$Iter$run$61$(self, f) {
-  const _func = self;
-  return _func(f);
-}
-function moonbitlang$core$builtin$$Iter$run$18$(self, f) {
-  const _func = self;
-  return _func(f);
-}
-function moonbitlang$core$builtin$$Eq$op_equal$15$(_x_159, _x_160) {
+function moonbitlang$core$builtin$$Eq$op_equal$13$(_x_159, _x_160) {
   if (_x_159 === 0) {
     if (_x_160 === 0) {
       return true;
@@ -7580,17 +7850,8 @@ function moonbitlang$core$builtin$$Eq$op_equal$15$(_x_159, _x_160) {
     }
   }
 }
-function moonbitlang$core$builtin$$Iter$any$14$(self, f) {
-  return moonbitlang$core$builtin$$op_notequal$15$(moonbitlang$core$builtin$$Iter$run$14$(self, (k) => f(k) ? 0 : 1), 1);
-}
-function moonbitlang$core$builtin$$Iter$any$32$(self, f) {
-  return moonbitlang$core$builtin$$op_notequal$15$(moonbitlang$core$builtin$$Iter$run$32$(self, (k) => f(k) ? 0 : 1), 1);
-}
-function moonbitlang$core$builtin$$Iter$all$61$(self, f) {
-  return moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter$run$61$(self, (k) => !f(k) ? 0 : 1), 1);
-}
-function moonbitlang$core$builtin$$Iter$all$32$(self, f) {
-  return moonbitlang$core$builtin$$Eq$op_equal$15$(moonbitlang$core$builtin$$Iter$run$32$(self, (k) => !f(k) ? 0 : 1), 1);
+function moonbitlang$core$builtin$$Iter$any$17$(self, f) {
+  return moonbitlang$core$builtin$$op_notequal$13$(moonbitlang$core$builtin$$Iter$run$17$(self, (k) => f(k) ? 0 : 1), 1);
 }
 function moonbitlang$core$builtin$$Iter$find_first$82$(self, f) {
   const _foreach_result = { val: $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Continue$8$ };
@@ -7630,7 +7891,15 @@ function moonbitlang$core$builtin$$Iter$to_array$10$(self) {
   });
   return result;
 }
-function moonbitlang$core$builtin$$Iter$contains$18$(self, value) {
+function moonbitlang$core$builtin$$Iter$collect$12$(self) {
+  const result = [];
+  self((_p) => {
+    moonbitlang$core$array$$Array$push$12$(result, _p);
+    return 1;
+  });
+  return result;
+}
+function moonbitlang$core$builtin$$Iter$contains$96$(self, value) {
   const _foreach_result = { val: $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Continue$9$ };
   self((v) => {
     if (moonbitlang$yacc$lib$grm$$Nonterminal$op_equal(v, value)) {
@@ -7690,38 +7959,154 @@ function moonbitlang$core$builtin$$Iter$contains$10$(self, value) {
     }
   }
 }
-function moonbitlang$core$builtin$$Show$output$153$(self, logger) {
+function moonbitlang$core$builtin$$Show$output$165$(self, logger) {
   logger.method_0(logger.self, Error$$to_string(self));
 }
-function moonbitlang$x$fs$internal$ffi$$read_file_to_string(path) {
-  return moonbitlang$x$fs$internal$ffi$$read_file_to_string_internal(path);
-}
-function moonbitlang$x$fs$internal$ffi$$write_string_to_file(path, content) {
-  moonbitlang$x$fs$internal$ffi$$write_string_to_file_internal(path, content);
-}
-function moonbitlang$x$fs$internal$ffi$$path_exists(path) {
-  return moonbitlang$x$fs$internal$ffi$$path_exists_internal(path);
-}
-function moonbitlang$x$fs$$IOError$to_string(self) {
-  const _NotFound = self;
-  const _x = _NotFound._0;
-  return `\`${_x}\` does not exist`;
-}
-function moonbitlang$core$builtin$$Show$output$149$(self, logger) {
-  logger.method_0(logger.self, moonbitlang$x$fs$$IOError$to_string(self));
-}
-function moonbitlang$x$fs$$write_string_to_file(path, content) {
-  moonbitlang$x$fs$internal$ffi$$write_string_to_file(path, content);
-}
-function moonbitlang$x$fs$$path_exists(path) {
-  return moonbitlang$x$fs$internal$ffi$$path_exists(path);
-}
-function moonbitlang$x$fs$$read_file_to_string(path) {
-  if (moonbitlang$x$fs$$path_exists(path)) {
-    return new Result$Ok$11$(moonbitlang$x$fs$internal$ffi$$read_file_to_string(path));
-  } else {
-    return new Result$Err$10$(new Error$moonbitlang$47$x$47$fs$46$IOError$46$NotFound(path));
+function moonbitlang$x$internal$ffi$$mbt_string_to_utf8_bytes(str, is_filename) {
+  const res = [];
+  const len = str.length;
+  let i = 0;
+  while (true) {
+    if (i < len) {
+      let c = str.charCodeAt(i);
+      if (55296 <= c && c <= 56319) {
+        c = c - 55296 | 0;
+        i = i + 1 | 0;
+        const l = str.charCodeAt(i) - 56320 | 0;
+        c = ((c << 10) + l | 0) + 65536 | 0;
+      }
+      if (c < 128) {
+        moonbitlang$core$array$$Array$push$12$(res, c & 255);
+      } else {
+        if (c < 2048) {
+          moonbitlang$core$array$$Array$push$12$(res, (192 + (c >> 6) | 0) & 255);
+          moonbitlang$core$array$$Array$push$12$(res, (128 + (c & 63) | 0) & 255);
+        } else {
+          if (c < 65536) {
+            moonbitlang$core$array$$Array$push$12$(res, (224 + (c >> 12) | 0) & 255);
+            moonbitlang$core$array$$Array$push$12$(res, (128 + (c >> 6 & 63) | 0) & 255);
+            moonbitlang$core$array$$Array$push$12$(res, (128 + (c & 63) | 0) & 255);
+          } else {
+            moonbitlang$core$array$$Array$push$12$(res, (240 + (c >> 18) | 0) & 255);
+            moonbitlang$core$array$$Array$push$12$(res, (128 + (c >> 12 & 63) | 0) & 255);
+            moonbitlang$core$array$$Array$push$12$(res, (128 + (c >> 6 & 63) | 0) & 255);
+            moonbitlang$core$array$$Array$push$12$(res, (128 + (c & 63) | 0) & 255);
+          }
+        }
+      }
+      i = i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
   }
+  if (is_filename) {
+    moonbitlang$core$array$$Array$push$12$(res, 0 & 255);
+  }
+  return moonbitlang$core$bytes$$Bytes$from_array(res);
+}
+function moonbitlang$x$internal$ffi$$utf8_bytes_to_mbt_string(bytes) {
+  const res = [];
+  const len = bytes.length;
+  let i = 0;
+  while (true) {
+    if (i < len) {
+      let c = bytes[i];
+      if (c < 128) {
+        moonbitlang$core$array$$Array$push$17$(res, c);
+        i = i + 1 | 0;
+      } else {
+        if (c < 224) {
+          if ((i + 1 | 0) >= len) {
+            break;
+          }
+          c = (c & 31) << 6 | bytes[i + 1 | 0] & 63;
+          moonbitlang$core$array$$Array$push$17$(res, c);
+          i = i + 2 | 0;
+        } else {
+          if (c < 240) {
+            if ((i + 2 | 0) >= len) {
+              break;
+            }
+            c = (c & 15) << 12 | (bytes[i + 1 | 0] & 63) << 6 | bytes[i + 2 | 0] & 63;
+            moonbitlang$core$array$$Array$push$17$(res, c);
+            i = i + 3 | 0;
+          } else {
+            if ((i + 3 | 0) >= len) {
+              break;
+            }
+            c = (c & 7) << 18 | (bytes[i + 1 | 0] & 63) << 12 | (bytes[i + 2 | 0] & 63) << 6 | bytes[i + 3 | 0] & 63;
+            c = c - 65536 | 0;
+            moonbitlang$core$array$$Array$push$17$(res, (c >> 10) + 55296 | 0);
+            moonbitlang$core$array$$Array$push$17$(res, (c & 1023) + 56320 | 0);
+            i = i + 4 | 0;
+          }
+        }
+      }
+      continue;
+    } else {
+      break;
+    }
+  }
+  return moonbitlang$core$string$$String$from_array(res);
+}
+function moonbitlang$x$fs$$read_file_to_bytes_internal(path) {
+  const res = moonbitlang$x$fs$$read_file_ffi(path);
+  if (res === -1) {
+    return new Result$Err$10$(new Error$moonbitlang$47$x$47$fs$46$IOError$46$IOError(moonbitlang$x$fs$$get_error_message_ffi()));
+  }
+  const content = moonbitlang$x$fs$$get_file_content_ffi();
+  return new Result$Ok$11$(moonbitlang$core$bytes$$Bytes$from_iter(moonbitlang$core$bytes$$Bytes$iter(content)));
+}
+function moonbitlang$x$fs$$read_file_to_string_internal(path, encoding) {
+  if (encoding === "utf8") {
+    const _bind = moonbitlang$x$fs$$read_file_to_bytes_internal(path);
+    let bytes;
+    if (_bind.$tag === 1) {
+      const _ok = _bind;
+      bytes = _ok._0;
+    } else {
+      return _bind;
+    }
+    return new Result$Ok$13$(moonbitlang$x$internal$ffi$$utf8_bytes_to_mbt_string(bytes));
+  } else {
+    return new Result$Err$12$(new Error$moonbitlang$47$x$47$fs$46$IOError$46$IOError(`Unsupported encoding: ${moonbitlang$core$builtin$$Show$to_string$10$(encoding)}, only utf8 is supported for now`));
+  }
+}
+function moonbitlang$x$fs$$write_bytes_to_file_internal(path, content) {
+  const res = moonbitlang$x$fs$$write_file_ffi(path, content);
+  if (res === -1) {
+    return new Result$Err$15$(new Error$moonbitlang$47$x$47$fs$46$IOError$46$IOError(moonbitlang$x$fs$$get_error_message_ffi()));
+  } else {
+    return new Result$Ok$14$(undefined);
+  }
+}
+function moonbitlang$x$fs$$write_string_to_file_internal(path, content, encoding) {
+  if (encoding === "utf8") {
+    const bytes = moonbitlang$x$internal$ffi$$mbt_string_to_utf8_bytes(content, false);
+    return moonbitlang$x$fs$$write_bytes_to_file_internal(path, bytes);
+  } else {
+    return new Result$Err$15$(new Error$moonbitlang$47$x$47$fs$46$IOError$46$IOError(`Unsupported encoding: ${moonbitlang$core$builtin$$Show$to_string$10$(encoding)}, only utf8 is supported for now`));
+  }
+}
+function moonbitlang$core$builtin$$Show$output$160$(_x_16, _x_17) {
+  const _IOError = _x_16;
+  const _x = _IOError._0;
+  _x_17.method_0(_x_17.self, "IOError(");
+  moonbitlang$core$builtin$$Logger$write_object$10$(_x_17, _x);
+  _x_17.method_0(_x_17.self, ")");
+}
+function moonbitlang$x$fs$$read_file_to_string(path, encoding) {
+  return moonbitlang$x$fs$$read_file_to_string_internal(path, encoding);
+}
+function moonbitlang$x$fs$$read_file_to_string$46$encoding$46$default() {
+  return "utf8";
+}
+function moonbitlang$x$fs$$write_string_to_file(path, content, encoding) {
+  return moonbitlang$x$fs$$write_string_to_file_internal(path, content, encoding);
+}
+function moonbitlang$x$fs$$write_string_to_file$46$encoding$46$default() {
+  return "utf8";
 }
 function moonbitlang$x$sys$internal$ffi$$get_cli_args() {
   return moonbitlang$x$sys$internal$ffi$$get_cli_args_internal();
@@ -7729,7 +8114,7 @@ function moonbitlang$x$sys$internal$ffi$$get_cli_args() {
 function moonbitlang$x$sys$$get_cli_args() {
   return moonbitlang$x$sys$internal$ffi$$get_cli_args();
 }
-function Yoorkin$trie$$T$lookup$158$(self, path) {
+function Yoorkin$trie$$T$lookup$170$(self, path) {
   const _bind = moonbitlang$core$string$$String$to_array(path);
   let _tmp = { buf: _bind, start: 0, len: _bind.length };
   let _tmp$2 = self;
@@ -7744,7 +8129,7 @@ function Yoorkin$trie$$T$lookup$158$(self, path) {
       const _tmp$4 = 1 + _param.start | 0;
       const _some = _param.len - 0 | 0;
       const _x$2 = { buf: _tmp$3, start: _tmp$4, len: _some - 1 | 0 };
-      const _bind$2 = moonbitlang$core$immut$sorted_map$$T$op_get$40$(_param$2.forks, _x);
+      const _bind$2 = moonbitlang$core$immut$sorted_map$$T$op_get$41$(_param$2.forks, _x);
       if (_bind$2 === undefined) {
         return undefined;
       } else {
@@ -7757,11 +8142,11 @@ function Yoorkin$trie$$T$lookup$158$(self, path) {
     }
   }
 }
-function Yoorkin$trie$$T$add$158$(self, path, value) {
+function Yoorkin$trie$$T$add$170$(self, path, value) {
   const _bind = moonbitlang$core$string$$String$to_array(path);
-  return Yoorkin$trie$$add$46$aux$47$3100(value, { buf: _bind, start: 0, len: _bind.length }, self);
+  return Yoorkin$trie$$add$46$aux$47$3152(value, { buf: _bind, start: 0, len: _bind.length }, self);
 }
-function Yoorkin$trie$$add$46$aux$47$3100(value, _param1, _param2) {
+function Yoorkin$trie$$add$46$aux$47$3152(value, _param1, _param2) {
   if (_param1.len === 0) {
     return { value: value, forks: _param2.forks };
   } else {
@@ -7770,12 +8155,12 @@ function Yoorkin$trie$$add$46$aux$47$3100(value, _param1, _param2) {
     const _tmp$2 = 1 + _param1.start | 0;
     const _some = _param1.len - 0 | 0;
     const _x$2 = { buf: _tmp, start: _tmp$2, len: _some - 1 | 0 };
-    const subtree = moonbitlang$core$option$$Option$or$54$(moonbitlang$core$immut$sorted_map$$T$op_get$40$(_param2.forks, _x), { value: undefined, forks: moonbitlang$core$immut$sorted_map$$new$40$() });
-    return { value: _param2.value, forks: moonbitlang$core$immut$sorted_map$$T$add$40$(_param2.forks, _x, Yoorkin$trie$$add$46$aux$47$3100(value, _x$2, subtree)) };
+    const subtree = moonbitlang$core$option$$Option$or$54$(moonbitlang$core$immut$sorted_map$$T$op_get$41$(_param2.forks, _x), { value: undefined, forks: moonbitlang$core$immut$sorted_map$$new$41$() });
+    return { value: _param2.value, forks: moonbitlang$core$immut$sorted_map$$T$add$41$(_param2.forks, _x, Yoorkin$trie$$add$46$aux$47$3152(value, _x$2, subtree)) };
   }
 }
-function Yoorkin$trie$$empty$158$() {
-  return { value: undefined, forks: moonbitlang$core$immut$sorted_map$$new$40$() };
+function Yoorkin$trie$$empty$170$() {
+  return { value: undefined, forks: moonbitlang$core$immut$sorted_map$$new$41$() };
 }
 function Yoorkin$ArgParser$$interpret(trie, xs, fallback) {
   const _bind = 0;
@@ -7794,7 +8179,7 @@ function Yoorkin$ArgParser$$interpret(trie, xs, fallback) {
       const _bind$3 = 1 + _param_start | 0;
       const _some = _param_len - 0 | 0;
       const _bind$4 = _some - 1 | 0;
-      const _bind$5 = Yoorkin$trie$$T$lookup$158$(trie, _x);
+      const _bind$5 = Yoorkin$trie$$T$lookup$170$(trie, _x);
       if (_bind$5 === undefined) {
         fallback(_x);
         _tmp$2 = _bind$3;
@@ -7863,31 +8248,31 @@ function Yoorkin$ArgParser$$interpret(trie, xs, fallback) {
             }
           }
         }
-        moonbitlang$core$builtin$$println$10$(`missing argument for ${_x}`);
+        moonbitlang$core$builtin$$println$10$(`missing argument for ${moonbitlang$core$builtin$$Show$to_string$10$(_x)}`);
         return;
       }
     }
   }
 }
-function Yoorkin$ArgParser$$parse$46$aux$159$(_param1, _param2) {
+function Yoorkin$ArgParser$$parse$46$aux$171$(_param1, _param2) {
   const _x = _param1._0;
   const _x$2 = _param1._1;
   const _x$3 = _param2._0;
   const _x$4 = _param2._1;
   const _x$5 = _param2._2;
   const _x$6 = _param2._3;
-  const trie = Yoorkin$trie$$T$add$158$(Yoorkin$trie$$T$add$158$(_x, _x$3, _x$5), _x$4, _x$5);
-  const help_msg = `${_x$2}  ${_x$3}\t${_x$4}\t${_x$6}\n`;
+  const trie = Yoorkin$trie$$T$add$170$(Yoorkin$trie$$T$add$170$(_x, _x$3, _x$5), _x$4, _x$5);
+  const help_msg = `${_x$2}  ${moonbitlang$core$builtin$$Show$to_string$10$(_x$3)}\t${moonbitlang$core$builtin$$Show$to_string$10$(_x$4)}\t${_x$6}\n`;
   return { _0: trie, _1: help_msg };
 }
 function Yoorkin$ArgParser$$parse(speclist, rest, usage_msg, argv) {
-  const _bind = moonbitlang$core$array$$Array$fold$157$(speclist, { _0: Yoorkin$trie$$empty$158$(), _1: `${usage_msg}\n options:\n` }, Yoorkin$ArgParser$$parse$46$aux$159$);
+  const _bind = moonbitlang$core$array$$Array$fold$169$(speclist, { _0: Yoorkin$trie$$empty$170$(), _1: `${usage_msg}\n options:\n` }, Yoorkin$ArgParser$$parse$46$aux$171$);
   const _x = _bind._0;
   const _x$2 = _bind._1;
   const help_spec = new $64$Yoorkin$47$ArgParser$46$Spec$Unit(() => {
     moonbitlang$core$builtin$$println$10$(_x$2);
   });
-  const trie = Yoorkin$trie$$T$add$158$(Yoorkin$trie$$T$add$158$(_x, "--help", help_spec), "-h", help_spec);
+  const trie = Yoorkin$trie$$T$add$170$(Yoorkin$trie$$T$add$170$(_x, "--help", help_spec), "-h", help_spec);
   Yoorkin$ArgParser$$interpret(trie, argv, rest);
 }
 function moonbitlang$core$builtin$$Eq$op_equal$89$(self, other) {
@@ -7908,28 +8293,28 @@ function moonbitlang$yacc$lib$grm$$Nonterminal$op_equal(self, other) {
 function moonbitlang$yacc$lib$grm$$Nonterminal$compare(self, other) {
   return $compare_int(self.num, other.num);
 }
-function moonbitlang$core$builtin$$Hash$hash_combine$18$(self, hasher) {
+function moonbitlang$core$builtin$$Hash$hash_combine$96$(self, hasher) {
   moonbitlang$core$builtin$$Hasher$combine_int(hasher, self.num);
 }
-function moonbitlang$core$builtin$$Show$output$18$(self, logger) {
+function moonbitlang$core$builtin$$Show$output$96$(self, logger) {
   logger.method_0(logger.self, self.name);
 }
-function moonbitlang$core$builtin$$Eq$op_equal$61$(_x_112, _x_113) {
-  if (_x_112.$tag === 0) {
-    const _T = _x_112;
+function moonbitlang$core$builtin$$Eq$op_equal$61$(_x_99, _x_100) {
+  if (_x_99.$tag === 0) {
+    const _T = _x_99;
     const _x = _T._0;
-    if (_x_113.$tag === 0) {
-      const _T$2 = _x_113;
+    if (_x_100.$tag === 0) {
+      const _T$2 = _x_100;
       const _x$2 = _T$2._0;
       return moonbitlang$core$builtin$$Eq$op_equal$89$(_x, _x$2);
     } else {
       return false;
     }
   } else {
-    const _NT = _x_112;
+    const _NT = _x_99;
     const _x = _NT._0;
-    if (_x_113.$tag === 1) {
-      const _NT$2 = _x_113;
+    if (_x_100.$tag === 1) {
+      const _NT$2 = _x_100;
       const _x$2 = _NT$2._0;
       return moonbitlang$yacc$lib$grm$$Nonterminal$op_equal(_x, _x$2);
     } else {
@@ -7937,41 +8322,41 @@ function moonbitlang$core$builtin$$Eq$op_equal$61$(_x_112, _x_113) {
     }
   }
 }
-function moonbitlang$core$builtin$$Compare$compare$61$(_x_100, _x_101) {
-  if (_x_100.$tag === 0) {
-    const _T = _x_100;
+function moonbitlang$core$builtin$$Compare$compare$61$(_x_87, _x_88) {
+  if (_x_87.$tag === 0) {
+    const _T = _x_87;
     const _x = _T._0;
-    if (_x_101.$tag === 0) {
-      const _T$2 = _x_101;
+    if (_x_88.$tag === 0) {
+      const _T$2 = _x_88;
       const _x$2 = _T$2._0;
       return moonbitlang$core$builtin$$Compare$compare$89$(_x, _x$2);
     } else {
       return -1;
     }
   } else {
-    const _NT = _x_100;
+    const _NT = _x_87;
     const _x = _NT._0;
-    if (_x_101.$tag === 0) {
+    if (_x_88.$tag === 0) {
       return 1;
     } else {
-      const _NT$2 = _x_101;
+      const _NT$2 = _x_88;
       const _x$2 = _NT$2._0;
       return moonbitlang$yacc$lib$grm$$Nonterminal$compare(_x, _x$2);
     }
   }
 }
-function moonbitlang$core$builtin$$Hash$hash_combine$61$(_x_92, _x_93) {
-  if (_x_92.$tag === 0) {
-    const _T = _x_92;
+function moonbitlang$core$builtin$$Hash$hash_combine$61$(_x_79, _x_80) {
+  if (_x_79.$tag === 0) {
+    const _T = _x_79;
     const _x = _T._0;
-    moonbitlang$core$builtin$$Hasher$combine_int(_x_93, 0);
-    moonbitlang$core$builtin$$Hash$hash_combine$89$(_x, _x_93);
+    moonbitlang$core$builtin$$Hasher$combine_int(_x_80, 0);
+    moonbitlang$core$builtin$$Hash$hash_combine$89$(_x, _x_80);
     return;
   } else {
-    const _NT = _x_92;
+    const _NT = _x_79;
     const _x = _NT._0;
-    moonbitlang$core$builtin$$Hasher$combine_int(_x_93, 1);
-    moonbitlang$core$builtin$$Hash$hash_combine$18$(_x, _x_93);
+    moonbitlang$core$builtin$$Hasher$combine_int(_x_80, 1);
+    moonbitlang$core$builtin$$Hash$hash_combine$96$(_x, _x_80);
     return;
   }
 }
@@ -7984,15 +8369,15 @@ function moonbitlang$core$builtin$$Show$output$61$(self, logger) {
   } else {
     const _NT = self;
     const _x = _NT._0;
-    moonbitlang$core$builtin$$Logger$write_object$18$(logger, _x);
+    moonbitlang$core$builtin$$Logger$write_object$96$(logger, _x);
     return;
   }
 }
-function moonbitlang$core$builtin$$Eq$op_equal$32$(self, other) {
+function moonbitlang$core$builtin$$Eq$op_equal$33$(self, other) {
   return self.num === other.num;
 }
-function moonbitlang$yacc$lib$grm$$Production$output_with_opt_dot$160$(self, logger, dot) {
-  moonbitlang$core$builtin$$Logger$write_object$18$({ self: logger, method_0: (x, x$2) => {
+function moonbitlang$yacc$lib$grm$$Production$output_with_opt_dot$172$(self, logger, dot) {
+  moonbitlang$core$builtin$$Logger$write_object$96$({ self: logger, method_0: (x, x$2) => {
     x.method_0(x.self, x$2);
   }, method_1: (x, x$2, x$3, x$4) => {
     x.method_1(x.self, x$2, x$3, x$4);
@@ -8064,7 +8449,7 @@ function moonbitlang$yacc$lib$parser$$Lexbuf$substring(self, start, end) {
 function moonbitlang$yacc$lib$parser$$LexEngine$run(self, lexbuf) {
   let state = 1;
   let tagState = [];
-  const backtrace = moonbitlang$core$array$$Array$make$142$(self.code_blocks_n, undefined);
+  const backtrace = moonbitlang$core$array$$Array$make$153$(self.code_blocks_n, undefined);
   const _arr = self.start_tags;
   const _len = _arr.length;
   let _tmp = 0;
@@ -8094,7 +8479,7 @@ function moonbitlang$yacc$lib$parser$$LexEngine$run(self, lexbuf) {
       } else {
         const _Some = _bind;
         const _x = _Some;
-        moonbitlang$core$array$$Array$op_set$142$(backtrace, _x._0, { _0: lexbuf.pos, _1: state, _2: tagState });
+        moonbitlang$core$array$$Array$op_set$153$(backtrace, _x._0, { _0: lexbuf.pos, _1: state, _2: tagState });
       }
       const _bind$2 = moonbitlang$yacc$lib$parser$$Lexbuf$next(lexbuf);
       let b;
@@ -8156,7 +8541,7 @@ function moonbitlang$yacc$lib$parser$$LexEngine$run(self, lexbuf) {
         const _x$3 = _x._1;
         const _x$4 = _x._2;
         lexbuf.pos = _x$2;
-        const captures = moonbitlang$core$array$$Array$map$133$(moonbitlang$core$option$$Option$unwrap$109$(moonbitlang$core$array$$Array$op_get$86$(self.end_nodes, _x$3))._1, (_param1) => {
+        const captures = moonbitlang$core$array$$Array$map$141$(moonbitlang$core$option$$Option$unwrap$114$(moonbitlang$core$array$$Array$op_get$86$(self.end_nodes, _x$3))._1, (_param1) => {
           const _x$5 = _param1._0;
           const _x$6 = _x$5._0;
           const _x$7 = _x$5._1;
@@ -9115,7 +9500,7 @@ function moonbitlang$yacc$lib$parser$$code_percent_rbrace(sb, lexbuf) {
     const _x = _bind._0;
     switch (_x) {
       case 0: {
-        return new Result$Ok$12$(undefined);
+        return new Result$Ok$16$(undefined);
       }
       case 1: {
         const _x$2 = _bind._1;
@@ -9127,10 +9512,10 @@ function moonbitlang$yacc$lib$parser$$code_percent_rbrace(sb, lexbuf) {
         continue _L;
       }
       case 2: {
-        return new Result$Err$12$(Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$UnexpectedEndOfFile);
+        return new Result$Err$16$(Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$UnexpectedEndOfFile);
       }
       default: {
-        return new Result$Ok$12$(moonbitlang$core$builtin$$abort$8$("lex: fail to match"));
+        return new Result$Ok$16$(moonbitlang$core$builtin$$abort$8$("lex: fail to match"));
       }
     }
   }
@@ -9172,7 +9557,7 @@ function moonbitlang$yacc$lib$parser$$code_rangle(sb, lexbuf) {
     const _x = _bind._0;
     switch (_x) {
       case 0: {
-        return new Result$Ok$12$(undefined);
+        return new Result$Ok$16$(undefined);
       }
       case 1: {
         const _x$2 = _bind._1;
@@ -9184,10 +9569,10 @@ function moonbitlang$yacc$lib$parser$$code_rangle(sb, lexbuf) {
         continue _L;
       }
       case 2: {
-        return new Result$Err$12$(Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$UnexpectedEndOfFile);
+        return new Result$Err$16$(Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$UnexpectedEndOfFile);
       }
       default: {
-        return new Result$Ok$12$(moonbitlang$core$builtin$$abort$8$("lex: fail to match"));
+        return new Result$Ok$16$(moonbitlang$core$builtin$$abort$8$("lex: fail to match"));
       }
     }
   }
@@ -10237,7 +10622,7 @@ function moonbitlang$yacc$lib$parser$$code_rbrace(sb, subst, base, lexbuf) {
         continue _L;
       }
       case 1: {
-        return new Result$Ok$12$(undefined);
+        return new Result$Ok$16$(undefined);
       }
       case 2: {
         const _x$2 = _bind._1;
@@ -10268,7 +10653,7 @@ function moonbitlang$yacc$lib$parser$$code_rbrace(sb, subst, base, lexbuf) {
           }
           index = moonbitlang$core$builtin$$abort$9$(moonbitlang$core$builtin$$Show$to_string$1$(_try_err));
         }
-        moonbitlang$core$array$$Array$push$122$(subst$2, { start: _x$3 - base$2 | 0, end: _x$4 - base$2 | 0, desc: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$Dollar(index) });
+        moonbitlang$core$array$$Array$push$129$(subst$2, { start: _x$3 - base$2 | 0, end: _x$4 - base$2 | 0, desc: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$Dollar(index) });
         continue _L;
       }
       case 3: {
@@ -10330,7 +10715,7 @@ function moonbitlang$yacc$lib$parser$$code_rbrace(sb, subst, base, lexbuf) {
             _tmp$7 = $panic();
           }
         }
-        moonbitlang$core$array$$Array$push$122$(subst$2, { start: _tmp$5, end: _tmp$6, desc: _tmp$7 });
+        moonbitlang$core$array$$Array$push$129$(subst$2, { start: _tmp$5, end: _tmp$6, desc: _tmp$7 });
         continue _L;
       }
       case 4: {
@@ -10372,7 +10757,7 @@ function moonbitlang$yacc$lib$parser$$code_rbrace(sb, subst, base, lexbuf) {
             _tmp$10 = $panic();
           }
         }
-        moonbitlang$core$array$$Array$push$122$(subst$2, { start: _tmp$8, end: _tmp$9, desc: _tmp$10 });
+        moonbitlang$core$array$$Array$push$129$(subst$2, { start: _tmp$8, end: _tmp$9, desc: _tmp$10 });
         continue _L;
       }
       case 5: {
@@ -10394,10 +10779,10 @@ function moonbitlang$yacc$lib$parser$$code_rbrace(sb, subst, base, lexbuf) {
         continue _L;
       }
       case 7: {
-        return new Result$Err$12$(Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$UnexpectedEndOfFile);
+        return new Result$Err$16$(Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$UnexpectedEndOfFile);
       }
       default: {
-        return new Result$Ok$12$(moonbitlang$core$builtin$$abort$8$("lex: fail to match"));
+        return new Result$Ok$16$(moonbitlang$core$builtin$$abort$8$("lex: fail to match"));
       }
     }
   }
@@ -10473,16 +10858,16 @@ function moonbitlang$yacc$lib$parser$$comment_star_rparen(lexbuf) {
         continue _L;
       }
       case 1: {
-        return new Result$Ok$12$(undefined);
+        return new Result$Ok$16$(undefined);
       }
       case 2: {
         continue _L;
       }
       case 3: {
-        return new Result$Err$12$(Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$UnexpectedEndOfFile);
+        return new Result$Err$16$(Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$UnexpectedEndOfFile);
       }
       default: {
-        return new Result$Ok$12$(moonbitlang$core$builtin$$abort$8$("lex: fail to match"));
+        return new Result$Ok$16$(moonbitlang$core$builtin$$abort$8$("lex: fail to match"));
       }
     }
   }
@@ -10521,7 +10906,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$3 = _bind$3._0;
         const _x$4 = _bind$3._1;
         const t = moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$3, _x$4);
-        return new Result$Ok$13$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$IDENT(t), _1: _x$3, _2: _x$4 });
+        return new Result$Ok$17$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$IDENT(t), _1: _x$3, _2: _x$4 });
       }
       case 5: {
         const _x$5 = _bind._1;
@@ -10529,7 +10914,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$6 = _bind$4._0;
         const _x$7 = _bind$4._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$6, _x$7);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_START, _1: _x$6, _2: _x$7 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_START, _1: _x$6, _2: _x$7 });
       }
       case 6: {
         const _x$8 = _bind._1;
@@ -10537,7 +10922,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$9 = _bind$5._0;
         const _x$10 = _bind$5._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$9, _x$10);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_TOKEN, _1: _x$9, _2: _x$10 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_TOKEN, _1: _x$9, _2: _x$10 });
       }
       case 7: {
         const _x$11 = _bind._1;
@@ -10545,7 +10930,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$12 = _bind$6._0;
         const _x$13 = _bind$6._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$12, _x$13);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_TYPE, _1: _x$12, _2: _x$13 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_TYPE, _1: _x$12, _2: _x$13 });
       }
       case 8: {
         const _x$14 = _bind._1;
@@ -10553,7 +10938,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$15 = _bind$7._0;
         const _x$16 = _bind$7._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$15, _x$16);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_POSITION, _1: _x$15, _2: _x$16 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_POSITION, _1: _x$15, _2: _x$16 });
       }
       case 9: {
         const _x$17 = _bind._1;
@@ -10561,7 +10946,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$18 = _bind$8._0;
         const _x$19 = _bind$8._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$18, _x$19);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_LEFT, _1: _x$18, _2: _x$19 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_LEFT, _1: _x$18, _2: _x$19 });
       }
       case 10: {
         const _x$20 = _bind._1;
@@ -10569,7 +10954,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$21 = _bind$9._0;
         const _x$22 = _bind$9._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$21, _x$22);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_RIGHT, _1: _x$21, _2: _x$22 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_RIGHT, _1: _x$21, _2: _x$22 });
       }
       case 11: {
         const _x$23 = _bind._1;
@@ -10577,7 +10962,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$24 = _bind$10._0;
         const _x$25 = _bind$10._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$24, _x$25);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_NONASSOC, _1: _x$24, _2: _x$25 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_NONASSOC, _1: _x$24, _2: _x$25 });
       }
       case 12: {
         const _x$26 = _bind._1;
@@ -10585,7 +10970,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$27 = _bind$11._0;
         const _x$28 = _bind$11._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$27, _x$28);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_PREC, _1: _x$27, _2: _x$28 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_PREC, _1: _x$27, _2: _x$28 });
       }
       case 13: {
         const _x$29 = _bind._1;
@@ -10593,7 +10978,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$30 = _bind$12._0;
         const _x$31 = _bind$12._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$30, _x$31);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_DERIVE, _1: _x$30, _2: _x$31 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_DERIVE, _1: _x$30, _2: _x$31 });
       }
       case 14: {
         const _x$32 = _bind._1;
@@ -10603,12 +10988,12 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$33, _x$34);
         if (phase$2.val <= 0) {
           phase$2.val = phase$2.val + 1 | 0;
-          return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_PERCENT, _1: _x$33, _2: _x$34 });
+          return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_PERCENT, _1: _x$33, _2: _x$34 });
         } else {
           phase$2.val = phase$2.val + 1 | 0;
           const sb = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
           moonbitlang$yacc$lib$parser$$code_eof(sb, lexbuf$2);
-          return new Result$Ok$13$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_PERCENT_CODE_EOF(moonbitlang$core$builtin$$StringBuilder$to_string(sb)), _1: _x$33, _2: _x$34 });
+          return new Result$Ok$17$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_PERCENT_CODE_EOF(moonbitlang$core$builtin$$StringBuilder$to_string(sb)), _1: _x$33, _2: _x$34 });
         }
       }
       case 15: {
@@ -10621,7 +11006,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$38 = _bind$15._0;
         const _x$39 = _bind$15._1;
         const t2 = moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$38, _x$39);
-        return new Result$Ok$13$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$ARROW_CODE(t2), _1: _x$36, _2: _x$37 });
+        return new Result$Ok$17$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$ARROW_CODE(t2), _1: _x$36, _2: _x$37 });
       }
       case 16: {
         const _x$40 = _bind._1;
@@ -10629,7 +11014,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$41 = _bind$16._0;
         const _x$42 = _bind$16._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$41, _x$42);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$COLON, _1: _x$41, _2: _x$42 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$COLON, _1: _x$41, _2: _x$42 });
       }
       case 17: {
         const _x$43 = _bind._1;
@@ -10637,7 +11022,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$44 = _bind$17._0;
         const _x$45 = _bind$17._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$44, _x$45);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$BAR, _1: _x$44, _2: _x$45 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$BAR, _1: _x$44, _2: _x$45 });
       }
       case 18: {
         const _x$46 = _bind._1;
@@ -10645,7 +11030,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$47 = _bind$18._0;
         const _x$48 = _bind$18._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$47, _x$48);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$EQ, _1: _x$47, _2: _x$48 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$EQ, _1: _x$47, _2: _x$48 });
       }
       case 19: {
         const _x$49 = _bind._1;
@@ -10653,7 +11038,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$50 = _bind$19._0;
         const _x$51 = _bind$19._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$50, _x$51);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$SEMI, _1: _x$50, _2: _x$51 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$SEMI, _1: _x$50, _2: _x$51 });
       }
       case 20: {
         const _x$52 = _bind._1;
@@ -10669,7 +11054,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         } else {
           return _bind$21;
         }
-        return new Result$Ok$13$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_LBRACE_CODE_PERCENT_RBRACE(moonbitlang$core$builtin$$StringBuilder$to_string(sb)), _1: _x$53, _2: _x$54 });
+        return new Result$Ok$17$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$PERCENT_LBRACE_CODE_PERCENT_RBRACE(moonbitlang$core$builtin$$StringBuilder$to_string(sb)), _1: _x$53, _2: _x$54 });
       }
       case 21: {
         const _x$55 = _bind._1;
@@ -10685,7 +11070,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         } else {
           return _bind$23;
         }
-        return new Result$Ok$13$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$LANGLE_CODE_RANGLE(moonbitlang$core$builtin$$StringBuilder$to_string(sb$2)), _1: _x$56, _2: _x$57 });
+        return new Result$Ok$17$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$LANGLE_CODE_RANGLE(moonbitlang$core$builtin$$StringBuilder$to_string(sb$2)), _1: _x$56, _2: _x$57 });
       }
       case 22: {
         const _x$58 = _bind._1;
@@ -10703,7 +11088,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         } else {
           return _bind$25;
         }
-        return new Result$Ok$13$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$LBRACE_CODE_RBRACE({ _0: moonbitlang$core$builtin$$StringBuilder$to_string(sb$3), _1: base, _2: subst }), _1: _x$59, _2: lexbuf$2.pos });
+        return new Result$Ok$17$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$LBRACE_CODE_RBRACE({ _0: moonbitlang$core$builtin$$StringBuilder$to_string(sb$3), _1: base, _2: subst }), _1: _x$59, _2: lexbuf$2.pos });
       }
       case 23: {
         const _x$61 = _bind._1;
@@ -10711,7 +11096,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$62 = _bind$26._0;
         const _x$63 = _bind$26._1;
         const t$2 = moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$62, _x$63);
-        return new Result$Ok$13$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$STRING(t$2), _1: _x$62, _2: _x$63 });
+        return new Result$Ok$17$({ _0: new $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$STRING(t$2), _1: _x$62, _2: _x$63 });
       }
       case 24: {
         const _x$64 = _bind._1;
@@ -10719,7 +11104,7 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$65 = _bind$27._0;
         const _x$66 = _bind$27._1;
         const t$3 = moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$65, _x$66);
-        return new Result$Err$13$(new Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$Unrecognized(t$3));
+        return new Result$Err$17$(new Error$moonbitlang$47$yacc$47$lib$47$parser$46$LexError$46$Unrecognized(t$3));
       }
       case 25: {
         const _x$67 = _bind._1;
@@ -10727,10 +11112,10 @@ function moonbitlang$yacc$lib$parser$$token(phase, lexbuf) {
         const _x$68 = _bind$28._0;
         const _x$69 = _bind$28._1;
         moonbitlang$yacc$lib$parser$$Lexbuf$substring(lexbuf$2, _x$68, _x$69);
-        return new Result$Ok$13$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$EOF, _1: _x$68, _2: _x$69 });
+        return new Result$Ok$17$({ _0: $64$moonbitlang$47$yacc$47$lib$47$parser$46$Token$EOF, _1: _x$68, _2: _x$69 });
       }
       default: {
-        return new Result$Ok$13$(moonbitlang$core$builtin$$abort$17$("lex: fail to match"));
+        return new Result$Ok$17$(moonbitlang$core$builtin$$abort$20$("lex: fail to match"));
       }
     }
   }
@@ -10740,347 +11125,6 @@ function moonbitlang$yacc$lib$parser$$new_lexer(input) {
 }
 function moonbitlang$yacc$lib$parser$$Lexer$next_token(self) {
   return moonbitlang$yacc$lib$parser$$token(self.phase, self.buf);
-}
-function moonbitlang$core$builtin$$Eq$op_equal$19$(_x_486, _x_487) {
-  switch (_x_486.$tag) {
-    case 0: {
-      const _Dollar = _x_486;
-      const _x = _Dollar._0;
-      if (_x_487.$tag === 0) {
-        const _Dollar$2 = _x_487;
-        const _x$2 = _Dollar$2._0;
-        return _x === _x$2;
-      } else {
-        return false;
-      }
-    }
-    case 1: {
-      if (_x_487.$tag === 1) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-    case 2: {
-      if (_x_487.$tag === 2) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-    case 3: {
-      if (_x_487.$tag === 3) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-    case 4: {
-      const _StartPosOf = _x_486;
-      const _x$2 = _StartPosOf._0;
-      if (_x_487.$tag === 4) {
-        const _StartPosOf$2 = _x_487;
-        const _x$3 = _StartPosOf$2._0;
-        return moonbitlang$core$builtin$$Eq$op_equal$161$(_x$2, _x$3);
-      } else {
-        return false;
-      }
-    }
-    case 5: {
-      const _EndPosOf = _x_486;
-      const _x$3 = _EndPosOf._0;
-      if (_x_487.$tag === 5) {
-        const _EndPosOf$2 = _x_487;
-        const _x$4 = _EndPosOf$2._0;
-        return moonbitlang$core$builtin$$Eq$op_equal$161$(_x$3, _x$4);
-      } else {
-        return false;
-      }
-    }
-    case 6: {
-      const _LocOf = _x_486;
-      const _x$4 = _LocOf._0;
-      if (_x_487.$tag === 6) {
-        const _LocOf$2 = _x_487;
-        const _x$5 = _LocOf$2._0;
-        return moonbitlang$core$builtin$$Eq$op_equal$161$(_x$4, _x$5);
-      } else {
-        return false;
-      }
-    }
-    case 7: {
-      if (_x_487.$tag === 7) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-    default: {
-      if (_x_487.$tag === 8) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-  }
-}
-function moonbitlang$core$builtin$$Compare$compare$19$(_x_466, _x_467) {
-  switch (_x_466.$tag) {
-    case 0: {
-      const _Dollar = _x_466;
-      const _x = _Dollar._0;
-      if (_x_467.$tag === 0) {
-        const _Dollar$2 = _x_467;
-        const _x$2 = _Dollar$2._0;
-        return $compare_int(_x, _x$2);
-      } else {
-        return -1;
-      }
-    }
-    case 1: {
-      switch (_x_467.$tag) {
-        case 0: {
-          return 1;
-        }
-        case 1: {
-          return 0;
-        }
-        default: {
-          return -1;
-        }
-      }
-    }
-    case 2: {
-      switch (_x_467.$tag) {
-        case 0: {
-          return 1;
-        }
-        case 1: {
-          return 1;
-        }
-        case 2: {
-          return 0;
-        }
-        default: {
-          return -1;
-        }
-      }
-    }
-    case 3: {
-      switch (_x_467.$tag) {
-        case 0: {
-          return 1;
-        }
-        case 1: {
-          return 1;
-        }
-        case 2: {
-          return 1;
-        }
-        case 3: {
-          return 0;
-        }
-        default: {
-          return -1;
-        }
-      }
-    }
-    case 4: {
-      const _StartPosOf = _x_466;
-      const _x$2 = _StartPosOf._0;
-      switch (_x_467.$tag) {
-        case 0: {
-          return 1;
-        }
-        case 1: {
-          return 1;
-        }
-        case 2: {
-          return 1;
-        }
-        case 3: {
-          return 1;
-        }
-        case 4: {
-          const _StartPosOf$2 = _x_467;
-          const _x$3 = _StartPosOf$2._0;
-          return moonbitlang$core$builtin$$Compare$compare$161$(_x$2, _x$3);
-        }
-        default: {
-          return -1;
-        }
-      }
-    }
-    case 5: {
-      const _EndPosOf = _x_466;
-      const _x$4 = _EndPosOf._0;
-      switch (_x_467.$tag) {
-        case 0: {
-          return 1;
-        }
-        case 1: {
-          return 1;
-        }
-        case 2: {
-          return 1;
-        }
-        case 3: {
-          return 1;
-        }
-        case 4: {
-          return 1;
-        }
-        case 5: {
-          const _EndPosOf$2 = _x_467;
-          const _x$5 = _EndPosOf$2._0;
-          return moonbitlang$core$builtin$$Compare$compare$161$(_x$4, _x$5);
-        }
-        default: {
-          return -1;
-        }
-      }
-    }
-    case 6: {
-      const _LocOf = _x_466;
-      const _x$6 = _LocOf._0;
-      switch (_x_467.$tag) {
-        case 0: {
-          return 1;
-        }
-        case 1: {
-          return 1;
-        }
-        case 2: {
-          return 1;
-        }
-        case 3: {
-          return 1;
-        }
-        case 4: {
-          return 1;
-        }
-        case 5: {
-          return 1;
-        }
-        case 6: {
-          const _LocOf$2 = _x_467;
-          const _x$7 = _LocOf$2._0;
-          return moonbitlang$core$builtin$$Compare$compare$161$(_x$6, _x$7);
-        }
-        default: {
-          return -1;
-        }
-      }
-    }
-    case 7: {
-      switch (_x_467.$tag) {
-        case 0: {
-          return 1;
-        }
-        case 1: {
-          return 1;
-        }
-        case 2: {
-          return 1;
-        }
-        case 3: {
-          return 1;
-        }
-        case 4: {
-          return 1;
-        }
-        case 5: {
-          return 1;
-        }
-        case 6: {
-          return 1;
-        }
-        case 7: {
-          return 0;
-        }
-        default: {
-          return -1;
-        }
-      }
-    }
-    default: {
-      switch (_x_467.$tag) {
-        case 0: {
-          return 1;
-        }
-        case 1: {
-          return 1;
-        }
-        case 2: {
-          return 1;
-        }
-        case 3: {
-          return 1;
-        }
-        case 4: {
-          return 1;
-        }
-        case 5: {
-          return 1;
-        }
-        case 6: {
-          return 1;
-        }
-        case 7: {
-          return 1;
-        }
-        default: {
-          return 0;
-        }
-      }
-    }
-  }
-}
-function moonbitlang$core$builtin$$Eq$op_equal$161$(_x_423, _x_424) {
-  if (_x_423.$tag === 0) {
-    const _Dollar = _x_423;
-    const _x = _Dollar._0;
-    if (_x_424.$tag === 0) {
-      const _Dollar$2 = _x_424;
-      const _x$2 = _Dollar$2._0;
-      return _x === _x$2;
-    } else {
-      return false;
-    }
-  } else {
-    const _Name = _x_423;
-    const _x = _Name._0;
-    if (_x_424.$tag === 1) {
-      const _Name$2 = _x_424;
-      const _x$2 = _Name$2._0;
-      return _x === _x$2;
-    } else {
-      return false;
-    }
-  }
-}
-function moonbitlang$core$builtin$$Compare$compare$161$(_x_411, _x_412) {
-  if (_x_411.$tag === 0) {
-    const _Dollar = _x_411;
-    const _x = _Dollar._0;
-    if (_x_412.$tag === 0) {
-      const _Dollar$2 = _x_412;
-      const _x$2 = _Dollar$2._0;
-      return $compare_int(_x, _x$2);
-    } else {
-      return -1;
-    }
-  } else {
-    const _Name = _x_411;
-    const _x = _Name._0;
-    if (_x_412.$tag === 0) {
-      return 1;
-    } else {
-      const _Name$2 = _x_412;
-      const _x$2 = _Name$2._0;
-      return moonbitlang$core$string$$String$compare(_x, _x$2);
-    }
-  }
 }
 function moonbitlang$yacc$lib$parser$$Token$kind(self) {
   switch (self.$tag) {
@@ -11152,7 +11196,7 @@ function moonbitlang$yacc$lib$parser$$Token$kind(self) {
     }
   }
 }
-function moonbitlang$core$builtin$$Show$output$121$(self, logger) {
+function moonbitlang$core$builtin$$Show$output$128$(self, logger) {
   let _tmp;
   switch (self) {
     case 0: {
@@ -11264,7 +11308,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_0(_last_pos, _args) {
         if (_bind$4.$tag === 4) {
           const _YYObj_Code_$2 = _bind$4;
           const _x$4 = _YYObj_Code_$2._0;
-          return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj_ParserSpec$46$YYObj_ParserSpec({ header: _x, trailer: _x$4, decls: moonbitlang$core$immut$list$$T$to_array$47$(_x$2), rules: moonbitlang$core$immut$list$$T$to_array$46$(_x$3) });
+          return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj_ParserSpec$46$YYObj_ParserSpec({ header: _x, trailer: _x$4, decls: moonbitlang$core$immut$list$$T$to_array$48$(_x$2), rules: moonbitlang$core$immut$list$$T$to_array$47$(_x$3) });
         } else {
           return $panic();
         }
@@ -11323,7 +11367,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_6(_last_pos, _args) {
     if (_bind$2.$tag === 5) {
       const _YYObj__immut_list_T_Declaration_ = _bind$2;
       const _x$2 = _YYObj__immut_list_T_Declaration_._0;
-      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Declaration_$46$YYObj__immut_list_T_Declaration_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$14$(_x, _x$2));
+      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Declaration_$46$YYObj__immut_list_T_Declaration_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$18$(_x, _x$2));
     } else {
       return $panic();
     }
@@ -11332,7 +11376,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_6(_last_pos, _args) {
   }
 }
 function moonbitlang$yacc$lib$parser$$yy_action_7(_last_pos, _args) {
-  return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Declaration_$46$YYObj__immut_list_T_Declaration_($64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$14$);
+  return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Declaration_$46$YYObj__immut_list_T_Declaration_($64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$18$);
 }
 function moonbitlang$yacc$lib$parser$$yy_action_8(_last_pos, _args) {
   const _bind = moonbitlang$core$array$$ArrayView$op_get$78$(_args, 1)._0;
@@ -11477,7 +11521,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_19(_last_pos, _args) {
   if (_bind.$tag === 12) {
     const _YYObj_Rule = _bind;
     const _x = _YYObj_Rule._0;
-    return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Rule_$46$YYObj__immut_list_T_Rule_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$15$(_x, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$15$));
+    return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Rule_$46$YYObj__immut_list_T_Rule_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$19$(_x, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$19$));
   } else {
     return $panic();
   }
@@ -11491,7 +11535,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_20(_last_pos, _args) {
     if (_bind$2.$tag === 6) {
       const _YYObj__immut_list_T_Rule_ = _bind$2;
       const _x$2 = _YYObj__immut_list_T_Rule_._0;
-      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Rule_$46$YYObj__immut_list_T_Rule_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$15$(_x, _x$2));
+      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Rule_$46$YYObj__immut_list_T_Rule_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$19$(_x, _x$2));
     } else {
       return $panic();
     }
@@ -11512,7 +11556,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_21(_last_pos, _args) {
       if (_bind$3.$tag === 13) {
         const _YYObj__immut_list_T_Clause_ = _bind$3;
         const _x$3 = _YYObj__immut_list_T_Clause_._0;
-        return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj_Rule$46$YYObj_Rule({ nonterminal: _x, type_: _x$2, clauses: moonbitlang$core$immut$list$$T$to_array$45$(_x$3) });
+        return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj_Rule$46$YYObj_Rule({ nonterminal: _x, type_: _x$2, clauses: moonbitlang$core$immut$list$$T$to_array$46$(_x$3) });
       } else {
         return $panic();
       }
@@ -11541,7 +11585,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_24(_last_pos, _args) {
   if (_bind.$tag === 14) {
     const _YYObj_Clause = _bind;
     const _x = _YYObj_Clause._0;
-    return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Clause_$46$YYObj__immut_list_T_Clause_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$16$(_x, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$16$));
+    return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Clause_$46$YYObj__immut_list_T_Clause_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$20$(_x, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$20$));
   } else {
     return $panic();
   }
@@ -11555,7 +11599,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_25(_last_pos, _args) {
     if (_bind$2.$tag === 13) {
       const _YYObj__immut_list_T_Clause_ = _bind$2;
       const _x$2 = _YYObj__immut_list_T_Clause_._0;
-      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Clause_$46$YYObj__immut_list_T_Clause_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$16$(_x, _x$2));
+      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Clause_$46$YYObj__immut_list_T_Clause_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$20$(_x, _x$2));
     } else {
       return $panic();
     }
@@ -11576,7 +11620,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_26(_last_pos, _args) {
       if (_bind$3.$tag === 17) {
         const _YYObj_ClauseAction = _bind$3;
         const _x$3 = _YYObj_ClauseAction._0;
-        return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj_Clause$46$YYObj_Clause({ items: moonbitlang$core$immut$list$$T$to_array$44$(_x), prec: _x$2, action: _x$3 });
+        return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj_Clause$46$YYObj_Clause({ items: moonbitlang$core$immut$list$$T$to_array$45$(_x), prec: _x$2, action: _x$3 });
       } else {
         return $panic();
       }
@@ -11627,7 +11671,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_31(_last_pos, _args) {
     if (_bind$2.$tag === 15) {
       const _YYObj__immut_list_T_ClauseItem_ = _bind$2;
       const _x$2 = _YYObj__immut_list_T_ClauseItem_._0;
-      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_ClauseItem_$46$YYObj__immut_list_T_ClauseItem_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$17$(_x, _x$2));
+      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_ClauseItem_$46$YYObj__immut_list_T_ClauseItem_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$21$(_x, _x$2));
     } else {
       return $panic();
     }
@@ -11636,7 +11680,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_31(_last_pos, _args) {
   }
 }
 function moonbitlang$yacc$lib$parser$$yy_action_32(_last_pos, _args) {
-  return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_ClauseItem_$46$YYObj__immut_list_T_ClauseItem_($64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$17$);
+  return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_ClauseItem_$46$YYObj__immut_list_T_ClauseItem_($64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$21$);
 }
 function moonbitlang$yacc$lib$parser$$yy_action_33(_last_pos, _args) {
   const _bind = moonbitlang$core$array$$ArrayView$op_get$78$(_args, 0)._0;
@@ -11690,7 +11734,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_37(_last_pos, _args) {
   if (_bind.$tag === 11) {
     const _YYObj_Symbol = _bind;
     const _x = _YYObj_Symbol._0;
-    return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Symbol_$46$YYObj__immut_list_T_Symbol_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$18$(_x, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$18$));
+    return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Symbol_$46$YYObj__immut_list_T_Symbol_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$22$(_x, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$22$));
   } else {
     return $panic();
   }
@@ -11704,7 +11748,7 @@ function moonbitlang$yacc$lib$parser$$yy_action_38(_last_pos, _args) {
     if (_bind$2.$tag === 10) {
       const _YYObj__immut_list_T_Symbol_ = _bind$2;
       const _x$2 = _YYObj__immut_list_T_Symbol_._0;
-      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Symbol_$46$YYObj__immut_list_T_Symbol_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$18$(_x, _x$2));
+      return new Error$moonbitlang$47$yacc$47$lib$47$parser$46$YYObj__immut_list_T_Symbol_$46$YYObj__immut_list_T_Symbol_(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$22$(_x, _x$2));
     } else {
       return $panic();
     }
@@ -12682,7 +12726,7 @@ function moonbitlang$yacc$lib$parser$$error(stack, token, loc) {
                 }
               }
             }
-            moonbitlang$core$array$$Array$push$121$(expected, kind);
+            moonbitlang$core$array$$Array$push$128$(expected, kind);
             break;
           }
           let stack$4;
@@ -12701,7 +12745,7 @@ function moonbitlang$yacc$lib$parser$$error(stack, token, loc) {
             const stack$5 = _tmp$3;
             const count$3 = _tmp$4;
             const symbol$4 = _tmp$5;
-            const stack$6 = moonbitlang$core$immut$list$$T$drop$48$(stack$5, count$3);
+            const stack$6 = moonbitlang$core$immut$list$$T$drop$49$(stack$5, count$3);
             if (stack$6.$tag === 1) {
               const _Cons$2 = stack$6;
               const _x$2 = _Cons$2._0;
@@ -12755,9 +12799,9 @@ function moonbitlang$yacc$lib$parser$$error(stack, token, loc) {
       break;
     }
   }
-  return new Result$Err$19$(new Error$moonbitlang$47$yacc$47$lib$47$parser$46$ParseError$46$UnexpectedToken(token, loc, expected));
+  return new Result$Err$23$(new Error$moonbitlang$47$yacc$47$lib$47$parser$46$ParseError$46$UnexpectedToken(token, loc, expected));
 }
-function moonbitlang$yacc$lib$parser$$yy_parse$162$(read_token, start_pos, start, return_) {
+function moonbitlang$yacc$lib$parser$$yy_parse$173$(read_token, start_pos, start, return_) {
   const state_stack = { val: new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$6$(start, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$6$) };
   const data_stack = [];
   const last_pos = { val: start_pos };
@@ -12805,7 +12849,7 @@ function moonbitlang$yacc$lib$parser$$yy_parse$162$(read_token, start_pos, start
       _L$2: {
         switch (decision.$tag) {
           case 0: {
-            return new Result$Ok$20$(return_(moonbitlang$core$array$$Array$unsafe_pop$78$(data_stack)._0));
+            return new Result$Ok$24$(return_(moonbitlang$core$array$$Array$unsafe_pop$78$(data_stack)._0));
           }
           case 1: {
             const _Shift = decision;
@@ -12846,7 +12890,7 @@ function moonbitlang$yacc$lib$parser$$yy_parse$162$(read_token, start_pos, start
             break _L$2;
           }
           default: {
-            const _bind$4 = moonbitlang$core$option$$Option$unwrap$110$(lookahead);
+            const _bind$4 = moonbitlang$core$option$$Option$unwrap$115$(lookahead);
             const _x$8 = _bind$4._1;
             const _x$9 = _x$8._1;
             const _x$10 = _x$8._2;
@@ -12890,14 +12934,14 @@ function moonbitlang$yacc$lib$parser$$yy_parse$162$(read_token, start_pos, start
           const i = _tmp$4;
           if (i < count) {
             moonbitlang$core$array$$Array$unsafe_pop$78$(data_stack);
-            state_stack.val = moonbitlang$core$immut$list$$T$tail$48$(state_stack.val);
+            state_stack.val = moonbitlang$core$immut$list$$T$tail$49$(state_stack.val);
             _tmp$4 = i + 1 | 0;
             continue;
           } else {
             break;
           }
         }
-        state.val = moonbitlang$core$immut$list$$T$unsafe_head$48$(state_stack.val);
+        state.val = moonbitlang$core$immut$list$$T$unsafe_head$49$(state_stack.val);
         moonbitlang$core$array$$Array$push$78$(data_stack, { _0: data, _1: start_pos$2, _2: end_pos });
         let action$2;
         let count$2;
@@ -12907,7 +12951,7 @@ function moonbitlang$yacc$lib$parser$$yy_parse$162$(read_token, start_pos, start
           const _bind$3 = _func$2(symbol);
           switch (_bind$3.$tag) {
             case 0: {
-              return new Result$Ok$20$(return_(moonbitlang$core$array$$Array$unsafe_pop$78$(data_stack)._0));
+              return new Result$Ok$24$(return_(moonbitlang$core$array$$Array$unsafe_pop$78$(data_stack)._0));
             }
             case 1: {
               const _Shift = _bind$3;
@@ -12952,7 +12996,7 @@ function moonbitlang$yacc$lib$parser$$yy_parse$162$(read_token, start_pos, start
   }
 }
 function moonbitlang$yacc$lib$parser$$spec(read_token, start_pos) {
-  return moonbitlang$yacc$lib$parser$$yy_parse$162$(read_token, start_pos, moonbitlang$yacc$lib$parser$$yy_state_0, (_param2) => {
+  return moonbitlang$yacc$lib$parser$$yy_parse$173$(read_token, start_pos, moonbitlang$yacc$lib$parser$$yy_state_0, (_param2) => {
     if (_param2.$tag === 7) {
       const _YYObj_ParserSpec = _param2;
       const _x = _YYObj_ParserSpec._0;
@@ -12962,7 +13006,7 @@ function moonbitlang$yacc$lib$parser$$spec(read_token, start_pos) {
     }
   });
 }
-function moonbitlang$core$builtin$$Eq$op_equal$50$(_x_25, _x_26) {
+function moonbitlang$core$builtin$$Eq$op_equal$51$(_x_25, _x_26) {
   switch (_x_25) {
     case 0: {
       if (_x_26 === 0) {
@@ -12987,7 +13031,7 @@ function moonbitlang$core$builtin$$Eq$op_equal$50$(_x_25, _x_26) {
     }
   }
 }
-function moonbitlang$core$builtin$$Hash$hash_combine$50$(_x_17, _x_18) {
+function moonbitlang$core$builtin$$Hash$hash_combine$51$(_x_17, _x_18) {
   switch (_x_17) {
     case 0: {
       moonbitlang$core$builtin$$Hasher$combine_int(_x_18, 0);
@@ -13003,15 +13047,15 @@ function moonbitlang$core$builtin$$Hash$hash_combine$50$(_x_17, _x_18) {
     }
   }
 }
-function moonbitlang$core$builtin$$ToJson$to_json$163$(_x_9) {
+function moonbitlang$core$builtin$$ToJson$to_json$174$(_x_9) {
   const $36$map = moonbitlang$core$builtin$$Map$from_array$74$([]);
-  moonbitlang$core$builtin$$Map$set$74$($36$map, "mappings", moonbitlang$core$array$$Array$to_json$128$(_x_9.mappings));
+  moonbitlang$core$builtin$$Map$set$74$($36$map, "mappings", moonbitlang$core$array$$Array$to_json$136$(_x_9.mappings));
   return new $64$moonbitlang$47$core$47$builtin$46$Json$Object($36$map);
 }
 function moonbitlang$yacc$lib$codegen$$SourceMap$new() {
   return { mappings: [] };
 }
-function moonbitlang$core$builtin$$ToJson$to_json$128$(_x_6) {
+function moonbitlang$core$builtin$$ToJson$to_json$136$(_x_6) {
   const $36$map = moonbitlang$core$builtin$$Map$from_array$74$([]);
   moonbitlang$core$builtin$$Map$set$74$($36$map, "source", moonbitlang$core$string$$String$to_json(_x_6.source));
   moonbitlang$core$builtin$$Map$set$74$($36$map, "original_offset", moonbitlang$core$int$$Int$to_json(_x_6.original_offset));
@@ -13019,8 +13063,8 @@ function moonbitlang$core$builtin$$ToJson$to_json$128$(_x_6) {
   moonbitlang$core$builtin$$Map$set$74$($36$map, "length", moonbitlang$core$int$$Int$to_json(_x_6.length));
   return new $64$moonbitlang$47$core$47$builtin$46$Json$Object($36$map);
 }
-function moonbitlang$yacc$lib$codegen$$SourceMapBuilder$add_mapping$163$(self, source, original_offset_in_utf8, generated_offset_in_utf8, length_in_utf8) {
-  moonbitlang$core$array$$Array$push$128$(self.mappings, { source: source, original_offset: original_offset_in_utf8, generated_offset: generated_offset_in_utf8, length: length_in_utf8 });
+function moonbitlang$yacc$lib$codegen$$SourceMapBuilder$add_mapping$174$(self, source, original_offset_in_utf8, generated_offset_in_utf8, length_in_utf8) {
+  moonbitlang$core$array$$Array$push$136$(self.mappings, { source: source, original_offset: original_offset_in_utf8, generated_offset: generated_offset_in_utf8, length: length_in_utf8 });
 }
 function moonbitlang$core$builtin$$Eq$op_equal$83$(_x_2, _x_3) {
   return _x_2 === _x_3;
@@ -13232,27 +13276,27 @@ function moonbitlang$yacc$lib$util$small_int_set$$SmallIntSet$subset(self, other
   }
   return true;
 }
-function moonbitlang$yacc$lib$util$hashmap2$$new$164$(capacity) {
+function moonbitlang$yacc$lib$util$hashmap2$$new$175$(capacity) {
   const bucket = $make_array_len_and_init(capacity, undefined);
   return { bucket: bucket, entry: undefined, bitmask: capacity - 1 | 0, size: 0 };
 }
-function moonbitlang$yacc$lib$util$hashmap2$$new$165$(capacity) {
+function moonbitlang$yacc$lib$util$hashmap2$$new$176$(capacity) {
   const bucket = $make_array_len_and_init(capacity, undefined);
   return { bucket: bucket, entry: undefined, bitmask: capacity - 1 | 0, size: 0 };
 }
-function moonbitlang$yacc$lib$util$hashmap2$$new$120$(capacity) {
+function moonbitlang$yacc$lib$util$hashmap2$$new$127$(capacity) {
   const bucket = $make_array_len_and_init(capacity, undefined);
   return { bucket: bucket, entry: undefined, bitmask: capacity - 1 | 0, size: 0 };
 }
-function moonbitlang$yacc$lib$util$hashmap2$$new$166$(capacity) {
+function moonbitlang$yacc$lib$util$hashmap2$$new$177$(capacity) {
   const bucket = $make_array_len_and_init(capacity, undefined);
   return { bucket: bucket, entry: undefined, bitmask: capacity - 1 | 0, size: 0 };
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$size$166$(self) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$size$177$(self) {
   return self.size;
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$iter$164$(self) {
-  return moonbitlang$core$builtin$$Iter$new$117$((yield_) => {
+function moonbitlang$yacc$lib$util$hashmap2$$T$iter$175$(self) {
+  return moonbitlang$core$builtin$$Iter$new$123$((yield_) => {
     let _tmp = self.entry;
     while (true) {
       const _param = _tmp;
@@ -13272,8 +13316,8 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$iter$164$(self) {
     }
   });
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$iter$165$(self) {
-  return moonbitlang$core$builtin$$Iter$new$118$((yield_) => {
+function moonbitlang$yacc$lib$util$hashmap2$$T$iter$176$(self) {
+  return moonbitlang$core$builtin$$Iter$new$125$((yield_) => {
     let _tmp = self.entry;
     while (true) {
       const _param = _tmp;
@@ -13293,8 +13337,8 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$iter$165$(self) {
     }
   });
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$iter2$120$(self) {
-  return moonbitlang$core$builtin$$Iter2$new$120$((yield_) => {
+function moonbitlang$yacc$lib$util$hashmap2$$T$iter2$127$(self) {
+  return moonbitlang$core$builtin$$Iter2$new$127$((yield_) => {
     let _tmp = self.entry;
     while (true) {
       const _param = _tmp;
@@ -13314,7 +13358,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$iter2$120$(self) {
     }
   });
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$166$(self, key, hash) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$177$(self, key, hash) {
   const bucket = self.bucket;
   const bitmask = self.bitmask;
   const ideal_index = hash & bitmask;
@@ -13327,7 +13371,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$166$(self, ke
     } else {
       const _Some = _bind;
       const _x = _Some;
-      if (_x.hash === hash && moonbitlang$core$builtin$$Eq$op_equal$167$(_x.key, key)) {
+      if (_x.hash === hash && moonbitlang$core$builtin$$Eq$op_equal$178$(_x.key, key)) {
         return _x;
       }
       if ((index - ideal_index | 0) > _x.psl) {
@@ -13338,31 +13382,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$166$(self, ke
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$164$(self, key, hash) {
-  const bucket = self.bucket;
-  const bitmask = self.bitmask;
-  const ideal_index = hash & bitmask;
-  let _tmp = ideal_index;
-  while (true) {
-    const index = _tmp;
-    const _bind = bucket[index];
-    if (_bind === undefined) {
-      return undefined;
-    } else {
-      const _Some = _bind;
-      const _x = _Some;
-      if (_x.hash === hash && moonbitlang$core$builtin$$Eq$op_equal$61$(_x.key, key)) {
-        return _x;
-      }
-      if ((index - ideal_index | 0) > _x.psl) {
-        return undefined;
-      }
-      _tmp = index + 1 & bitmask;
-      continue;
-    }
-  }
-}
-function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$165$(self, key, hash) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$175$(self, key, hash) {
   const bucket = self.bucket;
   const bitmask = self.bitmask;
   const ideal_index = hash & bitmask;
@@ -13386,7 +13406,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$165$(self, ke
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$120$(self, key, hash) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$176$(self, key, hash) {
   const bucket = self.bucket;
   const bitmask = self.bitmask;
   const ideal_index = hash & bitmask;
@@ -13399,7 +13419,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$120$(self, ke
     } else {
       const _Some = _bind;
       const _x = _Some;
-      if (_x.hash === hash && moonbitlang$core$builtin$$Eq$op_equal$96$(_x.key, key)) {
+      if (_x.hash === hash && moonbitlang$core$builtin$$Eq$op_equal$61$(_x.key, key)) {
         return _x;
       }
       if ((index - ideal_index | 0) > _x.psl) {
@@ -13410,7 +13430,31 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$120$(self, ke
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$166$(self, index, bitmask, entry) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$127$(self, key, hash) {
+  const bucket = self.bucket;
+  const bitmask = self.bitmask;
+  const ideal_index = hash & bitmask;
+  let _tmp = ideal_index;
+  while (true) {
+    const index = _tmp;
+    const _bind = bucket[index];
+    if (_bind === undefined) {
+      return undefined;
+    } else {
+      const _Some = _bind;
+      const _x = _Some;
+      if (_x.hash === hash && moonbitlang$core$builtin$$Eq$op_equal$97$(_x.key, key)) {
+        return _x;
+      }
+      if ((index - ideal_index | 0) > _x.psl) {
+        return undefined;
+      }
+      _tmp = index + 1 & bitmask;
+      continue;
+    }
+  }
+}
+function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$177$(self, index, bitmask, entry) {
   const bucket = self.bucket;
   let _tmp = index;
   let _tmp$2 = entry;
@@ -13439,7 +13483,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$166$(self, index, bitma
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$164$(self, index, bitmask, entry) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$175$(self, index, bitmask, entry) {
   const bucket = self.bucket;
   let _tmp = index;
   let _tmp$2 = entry;
@@ -13468,7 +13512,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$164$(self, index, bitma
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$165$(self, index, bitmask, entry) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$176$(self, index, bitmask, entry) {
   const bucket = self.bucket;
   let _tmp = index;
   let _tmp$2 = entry;
@@ -13497,7 +13541,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$165$(self, index, bitma
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$120$(self, index, bitmask, entry) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$127$(self, index, bitmask, entry) {
   const bucket = self.bucket;
   let _tmp = index;
   let _tmp$2 = entry;
@@ -13526,7 +13570,7 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$120$(self, index, bitma
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$grow$166$(self) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$grow$177$(self) {
   const capacity = Math.imul(self.bitmask + 1 | 0, 2) | 0;
   const bitmask = capacity - 1 | 0;
   const bucket = $make_array_len_and_init(capacity, undefined);
@@ -13541,13 +13585,13 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$grow$166$(self) {
       const _Some = _param;
       const _x = _Some;
       _x.psl = 0;
-      moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$166$(self, _x.hash & bitmask, bitmask, _x);
+      moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$177$(self, _x.hash & bitmask, bitmask, _x);
       _tmp = _x.prev;
       continue;
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$grow$164$(self) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$grow$175$(self) {
   const capacity = Math.imul(self.bitmask + 1 | 0, 2) | 0;
   const bitmask = capacity - 1 | 0;
   const bucket = $make_array_len_and_init(capacity, undefined);
@@ -13562,13 +13606,13 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$grow$164$(self) {
       const _Some = _param;
       const _x = _Some;
       _x.psl = 0;
-      moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$164$(self, _x.hash & bitmask, bitmask, _x);
+      moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$175$(self, _x.hash & bitmask, bitmask, _x);
       _tmp = _x.prev;
       continue;
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$grow$165$(self) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$grow$176$(self) {
   const capacity = Math.imul(self.bitmask + 1 | 0, 2) | 0;
   const bitmask = capacity - 1 | 0;
   const bucket = $make_array_len_and_init(capacity, undefined);
@@ -13583,13 +13627,13 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$grow$165$(self) {
       const _Some = _param;
       const _x = _Some;
       _x.psl = 0;
-      moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$165$(self, _x.hash & bitmask, bitmask, _x);
+      moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$176$(self, _x.hash & bitmask, bitmask, _x);
       _tmp = _x.prev;
       continue;
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$grow$120$(self) {
+function moonbitlang$yacc$lib$util$hashmap2$$T$grow$127$(self) {
   const capacity = Math.imul(self.bitmask + 1 | 0, 2) | 0;
   const bitmask = capacity - 1 | 0;
   const bucket = $make_array_len_and_init(capacity, undefined);
@@ -13604,24 +13648,24 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$grow$120$(self) {
       const _Some = _param;
       const _x = _Some;
       _x.psl = 0;
-      moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$120$(self, _x.hash & bitmask, bitmask, _x);
+      moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$127$(self, _x.hash & bitmask, bitmask, _x);
       _tmp = _x.prev;
       continue;
     }
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$164$(self, key, init) {
-  const hash = moonbitlang$core$builtin$$Hash$hash$145$(key);
-  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$164$(self, key, hash);
+function moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$175$(self, key, init) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$156$(key);
+  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$175$(self, key, hash);
   if (_bind === undefined) {
     if (self.size > (self.bitmask / 2 | 0)) {
-      moonbitlang$yacc$lib$util$hashmap2$$T$grow$164$(self);
+      moonbitlang$yacc$lib$util$hashmap2$$T$grow$175$(self);
     }
     const value = init(key);
     const entry = { value: value, psl: 0, key: key, hash: hash, prev: self.entry };
     self.entry = entry;
     self.size = self.size + 1 | 0;
-    moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$164$(self, hash & self.bitmask, self.bitmask, entry);
+    moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$175$(self, hash & self.bitmask, self.bitmask, entry);
     return value;
   } else {
     const _Some = _bind;
@@ -13629,18 +13673,18 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$164$(self, key, init)
     return _x.value;
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$166$(self, key, init) {
-  const hash = moonbitlang$core$builtin$$Hash$hash$167$(key);
-  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$166$(self, key, hash);
+function moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$177$(self, key, init) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$178$(key);
+  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$177$(self, key, hash);
   if (_bind === undefined) {
     if (self.size > (self.bitmask / 2 | 0)) {
-      moonbitlang$yacc$lib$util$hashmap2$$T$grow$166$(self);
+      moonbitlang$yacc$lib$util$hashmap2$$T$grow$177$(self);
     }
     const value = init(key);
     const entry = { value: value, psl: 0, key: key, hash: hash, prev: self.entry };
     self.entry = entry;
     self.size = self.size + 1 | 0;
-    moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$166$(self, hash & self.bitmask, self.bitmask, entry);
+    moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$177$(self, hash & self.bitmask, self.bitmask, entry);
     return value;
   } else {
     const _Some = _bind;
@@ -13648,17 +13692,17 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$166$(self, key, init)
     return _x.value;
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$set$120$(self, key, value) {
-  const hash = moonbitlang$core$builtin$$Hash$hash$146$(key);
-  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$120$(self, key, hash);
+function moonbitlang$yacc$lib$util$hashmap2$$T$set$127$(self, key, value) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$157$(key);
+  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$127$(self, key, hash);
   if (_bind === undefined) {
     if (self.size > (self.bitmask / 2 | 0)) {
-      moonbitlang$yacc$lib$util$hashmap2$$T$grow$120$(self);
+      moonbitlang$yacc$lib$util$hashmap2$$T$grow$127$(self);
     }
     const entry = { value: value, psl: 0, key: key, hash: hash, prev: self.entry };
     self.entry = entry;
     self.size = self.size + 1 | 0;
-    moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$120$(self, hash & self.bitmask, self.bitmask, entry);
+    moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$127$(self, hash & self.bitmask, self.bitmask, entry);
     return;
   } else {
     const _Some = _bind;
@@ -13667,17 +13711,17 @@ function moonbitlang$yacc$lib$util$hashmap2$$T$set$120$(self, key, value) {
     return;
   }
 }
-function moonbitlang$yacc$lib$util$hashmap2$$T$set$165$(self, key, value) {
-  const hash = moonbitlang$core$builtin$$Hash$hash$145$(key);
-  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$165$(self, key, hash);
+function moonbitlang$yacc$lib$util$hashmap2$$T$set$176$(self, key, value) {
+  const hash = moonbitlang$core$builtin$$Hash$hash$156$(key);
+  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$get_entry_with_hash$176$(self, key, hash);
   if (_bind === undefined) {
     if (self.size > (self.bitmask / 2 | 0)) {
-      moonbitlang$yacc$lib$util$hashmap2$$T$grow$165$(self);
+      moonbitlang$yacc$lib$util$hashmap2$$T$grow$176$(self);
     }
     const entry = { value: value, psl: 0, key: key, hash: hash, prev: self.entry };
     self.entry = entry;
     self.size = self.size + 1 | 0;
-    moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$165$(self, hash & self.bitmask, self.bitmask, entry);
+    moonbitlang$yacc$lib$util$hashmap2$$T$put_entry$176$(self, hash & self.bitmask, self.bitmask, entry);
     return;
   } else {
     const _Some = _bind;
@@ -13777,10 +13821,10 @@ function moonbitlang$yacc$lib$lr1$$EncodedLookaheadSet$disjoint(self, other) {
 function moonbitlang$yacc$lib$lr1$$EncodedLookaheadSet$subset(self, other) {
   return moonbitlang$yacc$lib$util$small_int_set$$SmallIntSet$subset(self, other);
 }
-function moonbitlang$core$builtin$$Eq$op_equal$167$(self, other) {
-  return moonbitlang$core$array$$Array$op_equal$36$(self.items, other.items);
+function moonbitlang$core$builtin$$Eq$op_equal$178$(self, other) {
+  return moonbitlang$core$array$$Array$op_equal$37$(self.items, other.items);
 }
-function moonbitlang$core$builtin$$Hash$hash$167$(self) {
+function moonbitlang$core$builtin$$Hash$hash$178$(self) {
   const _bind = self.hash;
   if (_bind === undefined) {
     const hasher = moonbitlang$core$builtin$$Hasher$new(moonbitlang$core$builtin$$Hasher$new$46$seed$46$default());
@@ -13811,12 +13855,12 @@ function moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$from_sorted_array(items) {
   return { items: items, hash: undefined };
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR0Item$decode(self, grammar) {
-  const production = moonbitlang$core$array$$Array$op_get$32$(grammar.productions, self >> 10);
+  const production = moonbitlang$core$array$$Array$op_get$33$(grammar.productions, self >> 10);
   const dot = self & 1023;
   return { production: production, dot: dot };
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$decode_iter(self, grammar) {
-  return moonbitlang$core$builtin$$Iter$new$119$((yield_) => {
+  return moonbitlang$core$builtin$$Iter$new$126$((yield_) => {
     let index = 0;
     const _arr = self.items;
     const _len = _arr.length;
@@ -13851,9 +13895,9 @@ function moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$interpret(self, s
   return _acc.val;
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$decode_item_groups(self, grammar) {
-  return moonbitlang$core$builtin$$Iter$new$116$((yield_) => {
-    const lookahead_set_array = moonbitlang$core$array$$Array$map$138$(self.core.closure_symbolic_lookahead_set, (symbolic_lookahead_set) => moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$interpret(symbolic_lookahead_set, self.kernel_lookahead_set_table));
-    const _foreach_result = { val: $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Continue$21$ };
+  return moonbitlang$core$builtin$$Iter$new$122$((yield_) => {
+    const lookahead_set_array = moonbitlang$core$array$$Array$map$149$(self.core.closure_symbolic_lookahead_set, (symbolic_lookahead_set) => moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$interpret(symbolic_lookahead_set, self.kernel_lookahead_set_table));
+    const _foreach_result = { val: $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Continue$25$ };
     const _bind = moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$decode_iter(self.core.closure_items, grammar);
     _bind((item) => {
       const _x = item._0;
@@ -13861,7 +13905,7 @@ function moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$decode_item_groups(self, gr
       const lookahead_set = moonbitlang$core$array$$Array$op_get$90$(lookahead_set_array, _x);
       const _bind$2 = yield_({ core: _x$2, lookahead_set: moonbitlang$yacc$lib$lr1$$EncodedLookaheadSet$decode_iter(lookahead_set, grammar) });
       if (_bind$2 === 0) {
-        _foreach_result.val = new $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Return$21$(0);
+        _foreach_result.val = new $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Return$25$(0);
         return 0;
       }
       return 1;
@@ -13892,10 +13936,10 @@ function moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$decode_item_groups(self, gr
   });
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$merge(self, other) {
-  return moonbitlang$core$builtin$$Eq$op_equal$168$(self.core, other.core) ? { core: self.core, kernel_lookahead_set_table: moonbitlang$core$array$$Array$mapi$154$(self.kernel_lookahead_set_table, (i, lookahead_set) => moonbitlang$yacc$lib$lr1$$EncodedLookaheadSet$union(lookahead_set, moonbitlang$core$array$$Array$op_get$90$(other.kernel_lookahead_set_table, i))) } : $panic();
+  return moonbitlang$core$builtin$$Eq$op_equal$179$(self.core, other.core) ? { core: self.core, kernel_lookahead_set_table: moonbitlang$core$array$$Array$mapi$166$(self.kernel_lookahead_set_table, (i, lookahead_set) => moonbitlang$yacc$lib$lr1$$EncodedLookaheadSet$union(lookahead_set, moonbitlang$core$array$$Array$op_get$90$(other.kernel_lookahead_set_table, i))) } : $panic();
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$subsume(self, other) {
-  if (moonbitlang$core$builtin$$Eq$op_equal$168$(self.core, other.core)) {
+  if (moonbitlang$core$builtin$$Eq$op_equal$179$(self.core, other.core)) {
     const len = self.kernel_lookahead_set_table.length;
     const self_table = self.kernel_lookahead_set_table;
     const other_table = other.kernel_lookahead_set_table;
@@ -13928,7 +13972,7 @@ function moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$subsume(self, other) {
   }
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$weak_compat(self, other) {
-  if (moonbitlang$core$builtin$$Eq$op_equal$168$(self.core, other.core)) {
+  if (moonbitlang$core$builtin$$Eq$op_equal$179$(self.core, other.core)) {
     const len = self.kernel_lookahead_set_table.length;
     let _tmp = 0;
     while (true) {
@@ -13970,36 +14014,36 @@ function moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$weak_compat(self, other) {
     return $panic();
   }
 }
-function moonbitlang$core$builtin$$Eq$op_equal$36$(_x_352, _x_353) {
+function moonbitlang$core$builtin$$Eq$op_equal$37$(_x_352, _x_353) {
   return _x_352 === _x_353;
 }
-function moonbitlang$core$builtin$$Compare$compare$36$(_x_348, _x_349) {
+function moonbitlang$core$builtin$$Compare$compare$37$(_x_348, _x_349) {
   return $compare_int(_x_348, _x_349);
 }
-function moonbitlang$core$builtin$$Hash$hash_combine$36$(_x_344, _x_345) {
+function moonbitlang$core$builtin$$Hash$hash_combine$37$(_x_344, _x_345) {
   moonbitlang$core$builtin$$Hash$hash_combine$9$(_x_344, _x_345);
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR0Item$new(production, dot) {
   return production.num << 10 | dot;
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR0Item$decode_production(self, grammar) {
-  return moonbitlang$core$array$$Array$op_get$32$(grammar.productions, self >> 10);
+  return moonbitlang$core$array$$Array$op_get$33$(grammar.productions, self >> 10);
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR0Item$decode_postdot(self, grammar) {
-  const production = moonbitlang$core$array$$Array$op_get$32$(grammar.productions, self >> 10);
+  const production = moonbitlang$core$array$$Array$op_get$33$(grammar.productions, self >> 10);
   const dot = self & 1023;
   return moonbitlang$core$array$$Array$get$61$(production.rhs, dot);
 }
 function moonbitlang$yacc$lib$lr1$$EncodedLR0Item$unsafe_shift(self) {
   return self + 1 | 0;
 }
-function moonbitlang$yacc$lib$lr1$$EpsilonLookaheadSet$op_add$123$(set1, set2) {
+function moonbitlang$yacc$lib$lr1$$EpsilonLookaheadSet$op_add$130$(set1, set2) {
   return set1.nullable ? { set: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$union(set1.set, set2.set), nullable: set2.nullable } : set1;
 }
-function moonbitlang$yacc$lib$lr1$$EpsilonLookaheadSet$union$123$(set1, set2) {
+function moonbitlang$yacc$lib$lr1$$EpsilonLookaheadSet$union$130$(set1, set2) {
   return { set: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$union(set1.set, set2.set), nullable: set1.nullable || set2.nullable };
 }
-function moonbitlang$yacc$lib$lr1$$compute_first_fn$123$(grammar) {
+function moonbitlang$yacc$lib$lr1$$compute_first_fn$130$(grammar) {
   const nt_first_map = moonbitlang$core$array$$Array$make$88$(grammar.nonterminals.length, undefined);
   const first = (symbols) => {
     if (symbols.len === 0) {
@@ -14021,9 +14065,9 @@ function moonbitlang$yacc$lib$lr1$$compute_first_fn$123$(grammar) {
         const _bind = moonbitlang$core$array$$Array$op_get$88$(nt_first_map, _x$3.num);
         if (_bind === undefined) {
           moonbitlang$core$array$$Array$op_set$88$(nt_first_map, _x$3.num, { set: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$empty(), nullable: false });
-          const set = moonbitlang$core$array$$Array$fold$156$(_x$3.productions, { set: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$empty(), nullable: false }, (acc, p) => {
+          const set = moonbitlang$core$array$$Array$fold$168$(_x$3.productions, { set: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$empty(), nullable: false }, (acc, p) => {
             const _bind$2 = p.rhs;
-            return moonbitlang$yacc$lib$lr1$$EpsilonLookaheadSet$union$123$(acc, first({ buf: _bind$2, start: 0, len: _bind$2.length }));
+            return moonbitlang$yacc$lib$lr1$$EpsilonLookaheadSet$union$130$(acc, first({ buf: _bind$2, start: 0, len: _bind$2.length }));
           });
           moonbitlang$core$array$$Array$op_set$88$(nt_first_map, _x$3.num, set);
           _tmp$3 = set;
@@ -14033,13 +14077,13 @@ function moonbitlang$yacc$lib$lr1$$compute_first_fn$123$(grammar) {
           _tmp$3 = _x$4;
         }
       }
-      return moonbitlang$yacc$lib$lr1$$EpsilonLookaheadSet$op_add$123$(_tmp$3, first(_x$2));
+      return moonbitlang$yacc$lib$lr1$$EpsilonLookaheadSet$op_add$130$(_tmp$3, first(_x$2));
     }
   };
   return first;
 }
-function moonbitlang$yacc$lib$lr1$$build_closure_fn$123$(grammar) {
-  const first = moonbitlang$yacc$lib$lr1$$compute_first_fn$123$(grammar);
+function moonbitlang$yacc$lib$lr1$$build_closure_fn$130$(grammar) {
+  const first = moonbitlang$yacc$lib$lr1$$compute_first_fn$130$(grammar);
   const node_by_item = moonbitlang$core$hashmap$$new$69$(moonbitlang$core$hashmap$$new$46$capacity$46$default$69$());
   const _arr = grammar.productions;
   const _len = _arr.length;
@@ -14055,7 +14099,7 @@ function moonbitlang$yacc$lib$lr1$$build_closure_fn$123$(grammar) {
         if (dot <= _end237) {
           const item = moonbitlang$yacc$lib$lr1$$EncodedLR0Item$new(production, dot);
           const partial_lookahead_set = dot < production.rhs.length ? first(moonbitlang$core$array$$Array$op_as_view$61$(production.rhs, dot + 1 | 0, undefined)) : { set: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$empty(), nullable: false };
-          const node = { item: item, partial_lookahead_set: partial_lookahead_set, epsilon_transitions: [], stamp: moonbitlang$yacc$lib$util$stamp$$initial(), predecessors: $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$22$, lookahead_set: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$empty() };
+          const node = { item: item, partial_lookahead_set: partial_lookahead_set, epsilon_transitions: [], stamp: moonbitlang$yacc$lib$util$stamp$$initial(), predecessors: $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$26$, lookahead_set: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$empty() };
           moonbitlang$core$hashmap$$T$op_set$69$(node_by_item, item, node);
           _tmp$2 = dot + 1 | 0;
           continue;
@@ -14089,7 +14133,7 @@ function moonbitlang$yacc$lib$lr1$$build_closure_fn$123$(grammar) {
           if (_i < _len$2) {
             const production = _arr$2[_i];
             const encoded_item = moonbitlang$yacc$lib$lr1$$EncodedLR0Item$new(production, 0);
-            moonbitlang$core$array$$Array$push$43$(node.epsilon_transitions, moonbitlang$core$option$$Option$unwrap$43$(moonbitlang$core$hashmap$$T$op_get$69$(node_by_item, encoded_item)));
+            moonbitlang$core$array$$Array$push$44$(node.epsilon_transitions, moonbitlang$core$option$$Option$unwrap$44$(moonbitlang$core$hashmap$$T$op_get$69$(node_by_item, encoded_item)));
             _tmp$2 = _i + 1 | 0;
             continue;
           } else {
@@ -14107,9 +14151,9 @@ function moonbitlang$yacc$lib$lr1$$build_closure_fn$123$(grammar) {
     item_set((item) => {
       const _x = item._0;
       const _x$2 = item._1;
-      const node = moonbitlang$core$option$$Option$unwrap$43$(moonbitlang$core$hashmap$$T$op_get$69$(node_by_item, _x));
+      const node = moonbitlang$core$option$$Option$unwrap$44$(moonbitlang$core$hashmap$$T$op_get$69$(node_by_item, _x));
       node.lookahead_set = _x$2;
-      moonbitlang$yacc$lib$lr1$$build_closure_fn$46$follow$47$4593(_env, node);
+      moonbitlang$yacc$lib$lr1$$build_closure_fn$46$follow$47$4589(_env, node);
       return 1;
     });
     const stamp$2 = moonbitlang$yacc$lib$util$stamp$$new();
@@ -14119,21 +14163,21 @@ function moonbitlang$yacc$lib$lr1$$build_closure_fn$123$(grammar) {
       const _i = _tmp$2;
       if (_i < _len$2) {
         const node = nodes[_i];
-        moonbitlang$yacc$lib$lr1$$build_closure_fn$46$walk$47$4594(stamp$2, node);
+        moonbitlang$yacc$lib$lr1$$build_closure_fn$46$walk$47$4590(stamp$2, node);
         _tmp$2 = _i + 1 | 0;
         continue;
       } else {
         break;
       }
     }
-    const closure = moonbitlang$core$array$$Array$map$135$(nodes, (node) => ({ _0: node.item, _1: node.lookahead_set }));
+    const closure = moonbitlang$core$array$$Array$map$145$(nodes, (node) => ({ _0: node.item, _1: node.lookahead_set }));
     const _len$3 = nodes.length;
     let _tmp$3 = 0;
     while (true) {
       const _i = _tmp$3;
       if (_i < _len$3) {
         const node = nodes[_i];
-        node.predecessors = $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$22$;
+        node.predecessors = $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$26$;
         node.lookahead_set = moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$empty();
         _tmp$3 = _i + 1 | 0;
         continue;
@@ -14141,29 +14185,29 @@ function moonbitlang$yacc$lib$lr1$$build_closure_fn$123$(grammar) {
         break;
       }
     }
-    moonbitlang$core$array$$Array$sort_by_key$35$(closure, (pair) => pair._0);
+    moonbitlang$core$array$$Array$sort_by_key$36$(closure, (pair) => pair._0);
     return closure;
   };
 }
-function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$visit$47$4592(_env, node, lookahead_set, parent) {
+function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$visit$47$4588(_env, node, lookahead_set, parent) {
   const stamp = _env._0;
   if (lookahead_set.nullable) {
-    node.predecessors = new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$22$(parent, node.predecessors);
+    node.predecessors = new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$26$(parent, node.predecessors);
   }
   if (moonbitlang$core$builtin$$Eq$op_equal$83$(node.stamp, stamp)) {
     node.lookahead_set = moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$union(node.lookahead_set, lookahead_set.set);
     return;
   } else {
     node.lookahead_set = lookahead_set.set;
-    moonbitlang$yacc$lib$lr1$$build_closure_fn$46$follow$47$4593(_env, node);
+    moonbitlang$yacc$lib$lr1$$build_closure_fn$46$follow$47$4589(_env, node);
     return;
   }
 }
-function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$follow$47$4593(_env, node) {
+function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$follow$47$4589(_env, node) {
   const nodes = _env._1;
   const stamp = _env._0;
   node.stamp = stamp;
-  moonbitlang$core$array$$Array$push$43$(nodes, node);
+  moonbitlang$core$array$$Array$push$44$(nodes, node);
   const _arr = node.epsilon_transitions;
   const _len = _arr.length;
   let _tmp = 0;
@@ -14171,7 +14215,7 @@ function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$follow$47$4593(_env, node
     const _i = _tmp;
     if (_i < _len) {
       const epsilon_transition = _arr[_i];
-      moonbitlang$yacc$lib$lr1$$build_closure_fn$46$visit$47$4592(_env, epsilon_transition, node.partial_lookahead_set, node);
+      moonbitlang$yacc$lib$lr1$$build_closure_fn$46$visit$47$4588(_env, epsilon_transition, node.partial_lookahead_set, node);
       _tmp = _i + 1 | 0;
       continue;
     } else {
@@ -14179,12 +14223,12 @@ function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$follow$47$4593(_env, node
     }
   }
 }
-function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$walk$47$4594(stamp, node) {
+function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$walk$47$4590(stamp, node) {
   if (moonbitlang$core$builtin$$op_notequal$83$(node.stamp, stamp)) {
     node.stamp = stamp;
-    const _bind = moonbitlang$core$immut$list$$T$iter$43$(node.predecessors);
+    const _bind = moonbitlang$core$immut$list$$T$iter$44$(node.predecessors);
     _bind((predecessor) => {
-      moonbitlang$yacc$lib$lr1$$build_closure_fn$46$walk$47$4594(stamp, predecessor);
+      moonbitlang$yacc$lib$lr1$$build_closure_fn$46$walk$47$4590(stamp, predecessor);
       node.lookahead_set = moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$union(node.lookahead_set, predecessor.lookahead_set);
       return 1;
     });
@@ -14195,13 +14239,13 @@ function moonbitlang$yacc$lib$lr1$$build_closure_fn$46$walk$47$4594(stamp, node)
 }
 function moonbitlang$yacc$lib$lr1$$resolve_conflicts(conflicts) {
   const errors = [];
-  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$iter2$120$(conflicts);
+  const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$iter2$127$(conflicts);
   _bind((location, decisions) => {
     const _x = location.state;
     const _x$2 = location.input;
     const shift = [];
     const reduce = [];
-    const _bind$2 = moonbitlang$core$immut$list$$T$iter$42$(decisions);
+    const _bind$2 = moonbitlang$core$immut$list$$T$iter$43$(decisions);
     _bind$2((decision) => {
       switch (decision.$tag) {
         case 0: {
@@ -14213,7 +14257,7 @@ function moonbitlang$yacc$lib$lr1$$resolve_conflicts(conflicts) {
         case 1: {
           const _Reduce = decision;
           const _x$4 = _Reduce._0;
-          moonbitlang$core$array$$Array$push$32$(reduce, _x$4);
+          moonbitlang$core$array$$Array$push$33$(reduce, _x$4);
           break;
         }
         case 2: {
@@ -14228,12 +14272,12 @@ function moonbitlang$yacc$lib$lr1$$resolve_conflicts(conflicts) {
     });
     if (shift.length <= 1) {
       if (reduce.length >= 1) {
-        moonbitlang$core$array$$Array$sort_by_key$37$(reduce, (prod) => prod.num);
-        const best_reduce = moonbitlang$core$array$$Array$op_get$32$(reduce, 0);
-        moonbitlang$core$array$$Array$push$125$(errors, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Reduce_conflict_resolved_by_presentation_order(_x, _x$2, reduce, best_reduce));
+        moonbitlang$core$array$$Array$sort_by_key$38$(reduce, (prod) => prod.num);
+        const best_reduce = moonbitlang$core$array$$Array$op_get$33$(reduce, 0);
+        moonbitlang$core$array$$Array$push$133$(errors, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Reduce_conflict_resolved_by_presentation_order(_x, _x$2, reduce, best_reduce));
         let decision;
         if (shift.length === 0) {
-          decision = new Result$Ok$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(best_reduce));
+          decision = new Result$Ok$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(best_reduce));
         } else {
           if (shift.length === 1) {
             const _x$3 = moonbitlang$core$array$$Array$op_get$93$(shift, 0);
@@ -14250,15 +14294,15 @@ function moonbitlang$yacc$lib$lr1$$resolve_conflicts(conflicts) {
             const _bind$3 = best_reduce.prec;
             if (term_prec === undefined) {
               if (_bind$3 === undefined) {
-                moonbitlang$core$array$$Array$push$125$(errors, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Shift_reduce_conflict_resolved_without_precedence(_x, _x$4, _x$5, best_reduce));
-                decision = new Result$Ok$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(_x$5));
+                moonbitlang$core$array$$Array$push$133$(errors, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Shift_reduce_conflict_resolved_without_precedence(_x, _x$4, _x$5, best_reduce));
+                decision = new Result$Ok$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(_x$5));
               } else {
-                decision = new Result$Ok$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(best_reduce));
+                decision = new Result$Ok$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(best_reduce));
               }
             } else {
               const _Some = term_prec;
               if (_bind$3 === undefined) {
-                decision = new Result$Ok$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(_x$5));
+                decision = new Result$Ok$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(_x$5));
               } else {
                 const _x$6 = _Some;
                 const _x$7 = _x$6._0;
@@ -14266,22 +14310,22 @@ function moonbitlang$yacc$lib$lr1$$resolve_conflicts(conflicts) {
                 const _Some$2 = _bind$3;
                 const _x$9 = _Some$2;
                 if (_x$7 > _x$9) {
-                  decision = new Result$Ok$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(_x$5));
+                  decision = new Result$Ok$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(_x$5));
                 } else {
                   if (_x$9 > _x$7) {
-                    decision = new Result$Ok$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(best_reduce));
+                    decision = new Result$Ok$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(best_reduce));
                   } else {
                     switch (_x$8) {
                       case 0: {
-                        decision = new Result$Ok$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(best_reduce));
+                        decision = new Result$Ok$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(best_reduce));
                         break;
                       }
                       case 1: {
-                        decision = new Result$Ok$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(_x$5));
+                        decision = new Result$Ok$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(_x$5));
                         break;
                       }
                       default: {
-                        decision = new Result$Err$23$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Shift_reduce_conflict_not_resolved_because_of_non_assoc(_x, _x$4, _x$5, best_reduce));
+                        decision = new Result$Err$27$(new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$ResolveConflictError$Shift_reduce_conflict_not_resolved_because_of_non_assoc(_x, _x$4, _x$5, best_reduce));
                       }
                     }
                   }
@@ -14299,7 +14343,7 @@ function moonbitlang$yacc$lib$lr1$$resolve_conflicts(conflicts) {
         } else {
           const _Err = decision;
           const _x$3 = _Err._0;
-          moonbitlang$core$array$$Array$push$125$(errors, _x$3);
+          moonbitlang$core$array$$Array$push$133$(errors, _x$3);
         }
       } else {
         $panic();
@@ -14323,11 +14367,11 @@ function moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$variable(var_) {
 function moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$union(self, other) {
   return { concrete_set: moonbitlang$yacc$lib$lr1$$EncodedLookaheadSet$union(self.concrete_set, other.concrete_set), vars: moonbitlang$yacc$lib$util$small_int_set$$SmallIntSet$union(self.vars, other.vars) };
 }
-function moonbitlang$core$builtin$$Show$output$116$(self, logger) {
+function moonbitlang$core$builtin$$Show$output$122$(self, logger) {
   logger.method_0(logger.self, "[");
   moonbitlang$core$builtin$$Logger$write_object$9$(logger, self.core.production.num);
   logger.method_0(logger.self, ", ");
-  moonbitlang$yacc$lib$grm$$Production$output_with_opt_dot$160$(self.core.production, logger, self.core.dot);
+  moonbitlang$yacc$lib$grm$$Production$output_with_opt_dot$172$(self.core.production, logger, self.core.dot);
   logger.method_0(logger.self, ", ");
   const first = { val: true };
   const _bind = self.lookahead_set;
@@ -14341,7 +14385,7 @@ function moonbitlang$core$builtin$$Show$output$116$(self, logger) {
   });
   logger.method_0(logger.self, "]");
 }
-function moonbitlang$core$builtin$$Eq$op_equal$42$(_x_174, _x_175) {
+function moonbitlang$core$builtin$$Eq$op_equal$43$(_x_174, _x_175) {
   switch (_x_174.$tag) {
     case 0: {
       const _Shift = _x_174;
@@ -14349,7 +14393,7 @@ function moonbitlang$core$builtin$$Eq$op_equal$42$(_x_174, _x_175) {
       if (_x_175.$tag === 0) {
         const _Shift$2 = _x_175;
         const _x$2 = _Shift$2._0;
-        return moonbitlang$core$builtin$$Eq$op_equal$111$(_x, _x$2);
+        return moonbitlang$core$builtin$$Eq$op_equal$119$(_x, _x$2);
       } else {
         return false;
       }
@@ -14360,7 +14404,7 @@ function moonbitlang$core$builtin$$Eq$op_equal$42$(_x_174, _x_175) {
       if (_x_175.$tag === 1) {
         const _Reduce$2 = _x_175;
         const _x$3 = _Reduce$2._0;
-        return moonbitlang$core$builtin$$Eq$op_equal$32$(_x$2, _x$3);
+        return moonbitlang$core$builtin$$Eq$op_equal$33$(_x$2, _x$3);
       } else {
         return false;
       }
@@ -14378,20 +14422,20 @@ function moonbitlang$core$builtin$$Eq$op_equal$42$(_x_174, _x_175) {
       if (_x_175.$tag === 3) {
         const _Conflict$2 = _x_175;
         const _x$4 = _Conflict$2._0;
-        return moonbitlang$core$builtin$$Eq$op_equal$41$(_x$3, _x$4);
+        return moonbitlang$core$builtin$$Eq$op_equal$42$(_x$3, _x$4);
       } else {
         return false;
       }
     }
   }
 }
-function moonbitlang$core$builtin$$Eq$op_equal$168$(self, other) {
+function moonbitlang$core$builtin$$Eq$op_equal$179$(self, other) {
   return self.num === other.num;
 }
-function moonbitlang$core$builtin$$Eq$op_equal$111$(self, other) {
+function moonbitlang$core$builtin$$Eq$op_equal$119$(self, other) {
   return self.num === other.num;
 }
-function moonbitlang$core$builtin$$Hash$hash_combine$111$(self, hasher) {
+function moonbitlang$core$builtin$$Hash$hash_combine$119$(self, hasher) {
   moonbitlang$core$builtin$$Hasher$combine_int(hasher, self.num);
 }
 function moonbitlang$yacc$lib$lr1$$LR1State$iter_item_groups(self) {
@@ -14408,15 +14452,15 @@ function moonbitlang$yacc$lib$lr1$$LR1State$set_action(self, input, decision) {
     if (_x.$tag === 3) {
       const _Conflict = _x;
       const _x$2 = _Conflict._0;
-      if (!moonbitlang$core$immut$list$$T$contains$42$(_x$2, decision)) {
-        moonbitlang$core$sorted_map$$T$op_set$57$(self.action, input, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Conflict(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$24$(decision, _x$2)));
+      if (!moonbitlang$core$immut$list$$T$contains$43$(_x$2, decision)) {
+        moonbitlang$core$sorted_map$$T$op_set$57$(self.action, input, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Conflict(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$28$(decision, _x$2)));
         return;
       } else {
         return;
       }
     } else {
-      if (moonbitlang$core$builtin$$op_notequal$42$(_x, decision)) {
-        moonbitlang$core$sorted_map$$T$op_set$57$(self.action, input, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Conflict(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$24$(decision, new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$24$(_x, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$24$))));
+      if (moonbitlang$core$builtin$$op_notequal$43$(_x, decision)) {
+        moonbitlang$core$sorted_map$$T$op_set$57$(self.action, input, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Conflict(new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$28$(decision, new $64$moonbitlang$47$core$47$immut$47$list$46$T$Cons$28$(_x, $64$moonbitlang$47$core$47$immut$47$list$46$T$Nil$28$))));
         return;
       } else {
         return;
@@ -14424,23 +14468,23 @@ function moonbitlang$yacc$lib$lr1$$LR1State$set_action(self, input, decision) {
     }
   }
 }
-function moonbitlang$core$builtin$$Eq$op_equal$96$(_x_152, _x_153) {
-  return moonbitlang$core$builtin$$Eq$op_equal$111$(_x_152.state, _x_153.state) && moonbitlang$core$builtin$$Eq$op_equal$60$(_x_152.input, _x_153.input);
+function moonbitlang$core$builtin$$Eq$op_equal$97$(_x_152, _x_153) {
+  return moonbitlang$core$builtin$$Eq$op_equal$119$(_x_152.state, _x_153.state) && moonbitlang$core$builtin$$Eq$op_equal$60$(_x_152.input, _x_153.input);
 }
-function moonbitlang$core$builtin$$Hash$hash_combine$96$(_x_148, _x_149) {
-  moonbitlang$core$builtin$$Hash$hash_combine$111$(_x_148.state, _x_149);
+function moonbitlang$core$builtin$$Hash$hash_combine$97$(_x_148, _x_149) {
+  moonbitlang$core$builtin$$Hash$hash_combine$119$(_x_148.state, _x_149);
   moonbitlang$core$builtin$$Hash$hash_combine$60$(_x_148.input, _x_149);
 }
-function moonbitlang$yacc$lib$lr1$$build$46$explore$169$(_env, kernel_items) {
+function moonbitlang$yacc$lib$lr1$$build$46$explore$180$(_env, kernel_items) {
   const grammar = _env._4;
   const node_transitions = _env._3;
   const node_by_kernel_items = _env._2;
   const closure = _env._1;
   const node_reductions = _env._0;
   const defer = { val: undefined };
-  const node = moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$166$(node_by_kernel_items, kernel_items, (kernel_items$2) => {
-    const symbolic_items = closure(moonbitlang$core$array$$Array$iter$31$(moonbitlang$core$array$$Array$mapi$155$(kernel_items$2.items, (index, item) => ({ _0: item, _1: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$variable(index) }))));
-    const node$2 = { num: moonbitlang$yacc$lib$util$hashmap2$$T$size$166$(node_by_kernel_items), closure_items: moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$from_sorted_array(moonbitlang$core$array$$Array$map$35$(symbolic_items, (item) => item._0)), closure_symbolic_lookahead_set: moonbitlang$core$array$$Array$map$134$(symbolic_items, (item) => item._1) };
+  const node = moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$177$(node_by_kernel_items, kernel_items, (kernel_items$2) => {
+    const symbolic_items = closure(moonbitlang$core$array$$Array$iter$32$(moonbitlang$core$array$$Array$mapi$167$(kernel_items$2.items, (index, item) => ({ _0: item, _1: moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$variable(index) }))));
+    const node$2 = { num: moonbitlang$yacc$lib$util$hashmap2$$T$size$177$(node_by_kernel_items), closure_items: moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$from_sorted_array(moonbitlang$core$array$$Array$map$36$(symbolic_items, (item) => item._0)), closure_symbolic_lookahead_set: moonbitlang$core$array$$Array$map$143$(symbolic_items, (item) => item._1) };
     defer.val = symbolic_items;
     return node$2;
   });
@@ -14460,7 +14504,7 @@ function moonbitlang$yacc$lib$lr1$$build$46$explore$169$(_env, kernel_items) {
         const _x$3 = symbolic_item._1;
         const _bind$2 = moonbitlang$yacc$lib$lr1$$EncodedLR0Item$decode_postdot(_x$2, grammar);
         if (_bind$2 === undefined) {
-          moonbitlang$core$array$$Array$push$124$(result, { _0: _x$3, _1: moonbitlang$yacc$lib$lr1$$EncodedLR0Item$decode_production(_x$2, grammar) });
+          moonbitlang$core$array$$Array$push$131$(result, { _0: _x$3, _1: moonbitlang$yacc$lib$lr1$$EncodedLR0Item$decode_production(_x$2, grammar) });
         }
         _tmp = _i + 1 | 0;
         continue;
@@ -14469,8 +14513,8 @@ function moonbitlang$yacc$lib$lr1$$build$46$explore$169$(_env, kernel_items) {
       }
     }
     moonbitlang$core$array$$Array$push$94$(node_reductions, result);
-    moonbitlang$core$array$$Array$push$95$(node_transitions, moonbitlang$yacc$lib$util$hashmap2$$new$165$(16));
-    const trans = moonbitlang$yacc$lib$util$hashmap2$$new$164$(16);
+    moonbitlang$core$array$$Array$push$95$(node_transitions, moonbitlang$yacc$lib$util$hashmap2$$new$176$(16));
+    const trans = moonbitlang$yacc$lib$util$hashmap2$$new$175$(16);
     const _len$2 = _x.length;
     let _tmp$2 = 0;
     while (true) {
@@ -14485,11 +14529,11 @@ function moonbitlang$yacc$lib$lr1$$build$46$explore$169$(_env, kernel_items) {
           const _Some$2 = _bind$2;
           const _x$4 = _Some$2;
           const next_item = moonbitlang$yacc$lib$lr1$$EncodedLR0Item$unsafe_shift(_x$2);
-          const _bind$3 = moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$164$(trans, _x$4, (_arg) => ({ _0: [], _1: [] }));
+          const _bind$3 = moonbitlang$yacc$lib$util$hashmap2$$T$get_or_init$175$(trans, _x$4, (_arg) => ({ _0: [], _1: [] }));
           const _x$5 = _bind$3._0;
           const _x$6 = _bind$3._1;
-          moonbitlang$core$array$$Array$push$36$(_x$5, next_item);
-          moonbitlang$core$array$$Array$push$123$(_x$6, _x$3);
+          moonbitlang$core$array$$Array$push$37$(_x$5, next_item);
+          moonbitlang$core$array$$Array$push$130$(_x$6, _x$3);
         }
         _tmp$2 = _i + 1 | 0;
         continue;
@@ -14497,20 +14541,20 @@ function moonbitlang$yacc$lib$lr1$$build$46$explore$169$(_env, kernel_items) {
         break;
       }
     }
-    const _bind$2 = moonbitlang$yacc$lib$util$hashmap2$$T$iter$164$(trans);
+    const _bind$2 = moonbitlang$yacc$lib$util$hashmap2$$T$iter$175$(trans);
     _bind$2((tran) => {
       const _x$2 = tran._0;
       const _x$3 = tran._1;
       const _x$4 = _x$3._0;
       const _x$5 = _x$3._1;
-      const target = moonbitlang$yacc$lib$lr1$$build$46$explore$169$(_env, moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$from_sorted_array(_x$4));
-      moonbitlang$yacc$lib$util$hashmap2$$T$set$165$(moonbitlang$core$array$$Array$op_get$95$(node_transitions, node.num), _x$2, { _0: target, _1: _x$5 });
+      const target = moonbitlang$yacc$lib$lr1$$build$46$explore$180$(_env, moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$from_sorted_array(_x$4));
+      moonbitlang$yacc$lib$util$hashmap2$$T$set$176$(moonbitlang$core$array$$Array$op_get$95$(node_transitions, node.num), _x$2, { _0: target, _1: _x$5 });
       return 1;
     });
   }
   return node;
 }
-function moonbitlang$yacc$lib$lr1$$build$46$fuse$170$(_env, family, candidate) {
+function moonbitlang$yacc$lib$lr1$$build$46$fuse$181$(_env, family, candidate) {
   const queue = _env._1;
   const next_state_num = _env._0;
   let _tmp = family;
@@ -14547,7 +14591,7 @@ function moonbitlang$yacc$lib$lr1$$build$46$fuse$170$(_env, family, candidate) {
     }
   }
 }
-function moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$171$(_env, pre_state) {
+function moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$182$(_env, pre_state) {
   const grammar = _env._1;
   const next_state_num = _env._0;
   const _bind = pre_state.state;
@@ -14562,7 +14606,7 @@ function moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$171$(_env, pre_state)
     return _x;
   }
 }
-function moonbitlang$yacc$lib$lr1$$build$46$check_add_conflict$172$(conflicts, state, input) {
+function moonbitlang$yacc$lib$lr1$$build$46$check_add_conflict$183$(conflicts, state, input) {
   const _bind = moonbitlang$core$sorted_map$$T$op_get$57$(state.action, input);
   if (_bind === undefined) {
     return;
@@ -14572,7 +14616,7 @@ function moonbitlang$yacc$lib$lr1$$build$46$check_add_conflict$172$(conflicts, s
     if (_x.$tag === 3) {
       const _Conflict = _x;
       const _x$2 = _Conflict._0;
-      moonbitlang$yacc$lib$util$hashmap2$$T$set$120$(conflicts, { state: state, input: input }, _x$2);
+      moonbitlang$yacc$lib$util$hashmap2$$T$set$127$(conflicts, { state: state, input: input }, _x$2);
       return;
     } else {
       return;
@@ -14580,8 +14624,8 @@ function moonbitlang$yacc$lib$lr1$$build$46$check_add_conflict$172$(conflicts, s
   }
 }
 function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
-  const closure = moonbitlang$yacc$lib$lr1$$build_closure_fn$123$(grammar);
-  const node_by_kernel_items = moonbitlang$yacc$lib$util$hashmap2$$new$166$(65536);
+  const closure = moonbitlang$yacc$lib$lr1$$build_closure_fn$130$(grammar);
+  const node_by_kernel_items = moonbitlang$yacc$lib$util$hashmap2$$new$177$(65536);
   const node_transitions = [];
   const node_reductions = [];
   const node_starts = [];
@@ -14593,7 +14637,7 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
     const _i = _tmp;
     if (_i < _len) {
       const start_production = _arr[_i];
-      moonbitlang$core$array$$Array$push$127$(node_starts, { _0: moonbitlang$yacc$lib$lr1$$build$46$explore$169$(_env, moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$from_sorted_array([moonbitlang$yacc$lib$lr1$$EncodedLR0Item$new(start_production, 0)])), _1: start_production });
+      moonbitlang$core$array$$Array$push$135$(node_starts, { _0: moonbitlang$yacc$lib$lr1$$build$46$explore$180$(_env, moonbitlang$yacc$lib$lr1$$EncodedLR0ItemSet$from_sorted_array([moonbitlang$yacc$lib$lr1$$EncodedLR0Item$new(start_production, 0)])), _1: start_production });
       _tmp = _i + 1 | 0;
       continue;
     } else {
@@ -14602,7 +14646,7 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
   }
   const next_state_num = { val: 0 };
   const starts = [];
-  const families = moonbitlang$core$array$$FixedArray$makei$34$(moonbitlang$yacc$lib$util$hashmap2$$T$size$166$(node_by_kernel_items), (_i) => []);
+  const families = moonbitlang$core$array$$FixedArray$makei$35$(moonbitlang$yacc$lib$util$hashmap2$$T$size$177$(node_by_kernel_items), (_i) => []);
   const queue = [];
   const _len$2 = node_starts.length;
   let _tmp$2 = 0;
@@ -14615,7 +14659,7 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
       const start_state = { items: { core: _x, kernel_lookahead_set_table: [moonbitlang$yacc$lib$lr1$$EncodedLookaheadSet$end_of_input()] }, state: undefined };
       moonbitlang$core$array$$Array$push$82$(families[start_state.items.core.num], start_state);
       next_state_num.val = next_state_num.val + 1 | 0;
-      moonbitlang$core$array$$Array$push$126$(starts, { _0: _x$2, _1: start_state });
+      moonbitlang$core$array$$Array$push$134$(starts, { _0: _x$2, _1: start_state });
       moonbitlang$core$array$$Array$push$82$(queue, start_state);
       _tmp$2 = _i + 1 | 0;
       continue;
@@ -14628,12 +14672,12 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
     if (!moonbitlang$core$array$$Array$is_empty$82$(queue)) {
       const state = moonbitlang$core$array$$Array$unsafe_pop$82$(queue);
       const trans = moonbitlang$core$array$$Array$op_get$95$(node_transitions, state.items.core.num);
-      const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$iter$165$(trans);
+      const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$iter$176$(trans);
       _bind((entry) => {
         const _x = entry._1;
         const _x$2 = _x._0;
         const _x$3 = _x._1;
-        const kernel_lookahead_set_table = moonbitlang$core$array$$Array$map$138$(_x$3, (symbolic_lookahead_set) => moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$interpret(symbolic_lookahead_set, state.items.kernel_lookahead_set_table));
+        const kernel_lookahead_set_table = moonbitlang$core$array$$Array$map$149$(_x$3, (symbolic_lookahead_set) => moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$interpret(symbolic_lookahead_set, state.items.kernel_lookahead_set_table));
         const target_state = { items: { core: _x$2, kernel_lookahead_set_table: kernel_lookahead_set_table }, state: undefined };
         next_state_num.val = next_state_num.val + 1 | 0;
         let _return_value;
@@ -14656,7 +14700,7 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
                 break;
               }
             }
-            moonbitlang$yacc$lib$lr1$$build$46$fuse$170$(_env$2, family, target_state);
+            moonbitlang$yacc$lib$lr1$$build$46$fuse$181$(_env$2, family, target_state);
             break _L;
           }
         }
@@ -14677,7 +14721,7 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
     if (_i < _len$3) {
       const entry = starts[_i];
       const _x = entry._1;
-      moonbitlang$core$array$$Array$push$111$(queue$2, moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$171$(_env$3, _x));
+      moonbitlang$core$array$$Array$push$119$(queue$2, moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$182$(_env$3, _x));
       _tmp$3 = _i + 1 | 0;
       continue;
     } else {
@@ -14686,15 +14730,15 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
   }
   const stamp = moonbitlang$yacc$lib$util$stamp$$new();
   while (true) {
-    if (!moonbitlang$core$array$$Array$is_empty$111$(queue$2)) {
-      const state = moonbitlang$core$array$$Array$unsafe_pop$111$(queue$2);
+    if (!moonbitlang$core$array$$Array$is_empty$119$(queue$2)) {
+      const state = moonbitlang$core$array$$Array$unsafe_pop$119$(queue$2);
       if (moonbitlang$core$builtin$$Eq$op_equal$83$(state.stamp, stamp)) {
         continue;
       }
       state.stamp = stamp;
-      moonbitlang$core$array$$Array$push$111$(states, state);
+      moonbitlang$core$array$$Array$push$119$(states, state);
       const trans = moonbitlang$core$array$$Array$op_get$95$(node_transitions, state.items.core.num);
-      const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$iter$165$(trans);
+      const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$iter$176$(trans);
       _bind((entry) => {
         const _x = entry._0;
         const _x$2 = entry._1;
@@ -14709,15 +14753,15 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
             const _x$5 = moonbitlang$core$array$$Array$op_get$82$(family, 0);
             pre_state = _x$5;
           } else {
-            const kernel_lookahead_set_table = moonbitlang$core$array$$Array$map$138$(_x$4, (symbolic_lookahead_set) => moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$interpret(symbolic_lookahead_set, state.items.kernel_lookahead_set_table));
+            const kernel_lookahead_set_table = moonbitlang$core$array$$Array$map$149$(_x$4, (symbolic_lookahead_set) => moonbitlang$yacc$lib$lr1$$EncodedSymbolicLookaheadSet$interpret(symbolic_lookahead_set, state.items.kernel_lookahead_set_table));
             const next_items = { core: _x$3, kernel_lookahead_set_table: kernel_lookahead_set_table };
             pre_state = moonbitlang$core$option$$Option$unwrap$82$(moonbitlang$core$builtin$$Iter$find_first$82$(moonbitlang$core$array$$Array$iter$82$(family), (state$2) => moonbitlang$yacc$lib$lr1$$EncodedLR1ItemSet$subsume(next_items, state$2.items)));
           }
         }
-        const target_state = moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$171$(_env$3, pre_state);
+        const target_state = moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$182$(_env$3, pre_state);
         moonbitlang$core$sorted_map$$T$op_set$56$(state.goto, _x, target_state);
         if (moonbitlang$core$builtin$$op_notequal$83$(target_state.stamp, stamp)) {
-          moonbitlang$core$array$$Array$push$111$(queue$2, target_state);
+          moonbitlang$core$array$$Array$push$119$(queue$2, target_state);
         }
         return 1;
       });
@@ -14739,7 +14783,7 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
       break;
     }
   }
-  const conflicts = moonbitlang$yacc$lib$util$hashmap2$$new$120$(16);
+  const conflicts = moonbitlang$yacc$lib$util$hashmap2$$new$127$(16);
   const _len$5 = states.length;
   let _tmp$5 = 0;
   while (true) {
@@ -14747,15 +14791,15 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
     if (_i < _len$5) {
       const state = states[_i];
       const core = state.items.core;
-      const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$iter$165$(moonbitlang$core$array$$Array$op_get$95$(node_transitions, core.num));
+      const _bind = moonbitlang$yacc$lib$util$hashmap2$$T$iter$176$(moonbitlang$core$array$$Array$op_get$95$(node_transitions, core.num));
       _bind((tran) => {
         const _x = tran._0;
         if (_x.$tag === 1) {
         } else {
           const _T = _x;
           const _x$2 = _T._0;
-          moonbitlang$yacc$lib$lr1$$LR1State$set_action(state, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Lookahead$Input(_x$2), new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(moonbitlang$core$option$$Option$unwrap$111$(moonbitlang$core$sorted_map$$T$op_get$56$(state.goto, new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$T(_x$2)))));
-          moonbitlang$yacc$lib$lr1$$build$46$check_add_conflict$172$(conflicts, state, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Lookahead$Input(_x$2));
+          moonbitlang$yacc$lib$lr1$$LR1State$set_action(state, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Lookahead$Input(_x$2), new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Shift(moonbitlang$core$option$$Option$unwrap$119$(moonbitlang$core$sorted_map$$T$op_get$56$(state.goto, new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$T(_x$2)))));
+          moonbitlang$yacc$lib$lr1$$build$46$check_add_conflict$183$(conflicts, state, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Lookahead$Input(_x$2));
         }
         return 1;
       });
@@ -14773,12 +14817,12 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
           _bind$2((item) => {
             const _bind$3 = moonbitlang$yacc$lib$lr1$$EncodedLookaheadSet$decode_iter(lookahead_set, grammar);
             _bind$3((lookahead) => {
-              if (moonbitlang$core$builtin$$Eq$op_equal$60$(lookahead, $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Lookahead$EndOfInput) && (moonbitlang$core$array$$Array$contains$32$(grammar.starts, _x$2) && item._1.dot === 1)) {
+              if (moonbitlang$core$builtin$$Eq$op_equal$60$(lookahead, $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Lookahead$EndOfInput) && (moonbitlang$core$array$$Array$contains$33$(grammar.starts, _x$2) && item._1.dot === 1)) {
                 moonbitlang$yacc$lib$lr1$$LR1State$set_action(state, lookahead, $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Accept);
               } else {
                 moonbitlang$yacc$lib$lr1$$LR1State$set_action(state, lookahead, new $64$moonbitlang$47$yacc$47$lib$47$lr1$46$Decision$Reduce(_x$2));
               }
-              moonbitlang$yacc$lib$lr1$$build$46$check_add_conflict$172$(conflicts, state, lookahead);
+              moonbitlang$yacc$lib$lr1$$build$46$check_add_conflict$183$(conflicts, state, lookahead);
               return 1;
             });
             return 1;
@@ -14795,10 +14839,10 @@ function moonbitlang$yacc$lib$lr1$$Automaton$build(grammar) {
       break;
     }
   }
-  const starts$2 = moonbitlang$core$array$$Array$map$137$(starts, (entry) => {
+  const starts$2 = moonbitlang$core$array$$Array$map$148$(starts, (entry) => {
     const _x = entry._0;
     const _x$2 = entry._1;
-    return { _0: _x, _1: moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$171$(_env$3, _x$2) };
+    return { _0: _x, _1: moonbitlang$yacc$lib$lr1$$build$46$state_from_pre$182$(_env$3, _x$2) };
   });
   return { states: states, starts: starts$2, conflicts: conflicts };
 }
@@ -14813,7 +14857,7 @@ function moonbitlang$yacc$lib$driver$util$$path_basename(path) {
     return moonbitlang$core$string$$String$substring(path, lastSlashIndex + 1 | 0, undefined);
   }
 }
-function moonbitlang$yacc$lib$driver$util$$exit$162$(code) {
+function moonbitlang$yacc$lib$driver$util$$exit$173$(code) {
   moonbitlang$yacc$lib$driver$util$$ffi_exit(code);
   return $panic();
 }
@@ -14821,7 +14865,7 @@ function moonbitlang$yacc$lib$driver$util$$exit$8$(code) {
   moonbitlang$yacc$lib$driver$util$$ffi_exit(code);
   $panic();
 }
-function moonbitlang$yacc$lib$driver$util$$exit$29$(code) {
+function moonbitlang$yacc$lib$driver$util$$exit$30$(code) {
   moonbitlang$yacc$lib$driver$util$$ffi_exit(code);
   return $panic();
 }
@@ -14834,29 +14878,29 @@ function moonbitlang$yacc$lib$util$logger_with_cursor$$new$46$cursor$46$default(
 function moonbitlang$yacc$lib$util$logger_with_cursor$$LoggerWithCursor$cursor(self) {
   return self.cursor;
 }
-function moonbitlang$core$builtin$$Logger$write_char$148$(self, char) {
+function moonbitlang$core$builtin$$Logger$write_char$159$(self, char) {
   const _tmp = self.logger;
   _tmp.method_3(_tmp.self, char);
   self.cursor = self.cursor + 1 | 0;
 }
-function moonbitlang$core$builtin$$Logger$write_string$148$(self, str) {
+function moonbitlang$core$builtin$$Logger$write_string$159$(self, str) {
   const _tmp = self.logger;
   _tmp.method_0(_tmp.self, str);
   self.cursor = self.cursor + str.length | 0;
 }
-function moonbitlang$core$builtin$$Logger$write_substring$148$(self, str, start, len) {
+function moonbitlang$core$builtin$$Logger$write_substring$159$(self, str, start, len) {
   const _tmp = self.logger;
   _tmp.method_2(_tmp.self, str, start, len);
   self.cursor = self.cursor + len | 0;
 }
-function moonbitlang$core$builtin$$Compare$compare$38$(_x_242, _x_243) {
-  switch (_x_242.$tag) {
+function moonbitlang$core$builtin$$Compare$compare$39$(_x_243, _x_244) {
+  switch (_x_243.$tag) {
     case 0: {
-      const _T = _x_242;
+      const _T = _x_243;
       const _x = _T._0;
       const _x$2 = _T._1;
-      if (_x_243.$tag === 0) {
-        const _T$2 = _x_243;
+      if (_x_244.$tag === 0) {
+        const _T$2 = _x_244;
         const _x$3 = _T$2._0;
         const _x$4 = _T$2._1;
         const _bind = $compare_int(_x, _x$3);
@@ -14870,15 +14914,15 @@ function moonbitlang$core$builtin$$Compare$compare$38$(_x_242, _x_243) {
       }
     }
     case 1: {
-      const _NT = _x_242;
+      const _NT = _x_243;
       const _x$3 = _NT._0;
       const _x$4 = _NT._1;
-      switch (_x_243.$tag) {
+      switch (_x_244.$tag) {
         case 0: {
           return 1;
         }
         case 1: {
-          const _NT$2 = _x_243;
+          const _NT$2 = _x_244;
           const _x$5 = _NT$2._0;
           const _x$6 = _NT$2._1;
           const _bind = $compare_int(_x$3, _x$5);
@@ -14894,7 +14938,7 @@ function moonbitlang$core$builtin$$Compare$compare$38$(_x_242, _x_243) {
       }
     }
     default: {
-      switch (_x_243.$tag) {
+      switch (_x_244.$tag) {
         case 0: {
           return 1;
         }
@@ -14913,32 +14957,32 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$CodegenSymbol$to_string(self) {
     case 0: {
       const _T = self;
       const _x = _T._1;
-      return `T_${_x}`;
+      return `T_${moonbitlang$core$builtin$$Show$to_string$10$(_x)}`;
     }
     case 1: {
       const _NT = self;
       const _x$2 = _NT._1;
-      return `NT_${_x$2}`;
+      return `NT_${moonbitlang$core$builtin$$Show$to_string$10$(_x$2)}`;
     }
     default: {
       return "EOI";
     }
   }
 }
-function moonbitlang$core$builtin$$Eq$op_equal$59$(_x_207, _x_208) {
-  switch (_x_207.$tag) {
+function moonbitlang$core$builtin$$Eq$op_equal$59$(_x_208, _x_209) {
+  switch (_x_208.$tag) {
     case 0: {
-      if (_x_208.$tag === 0) {
+      if (_x_209.$tag === 0) {
         return true;
       } else {
         return false;
       }
     }
     case 1: {
-      const _Shift = _x_207;
+      const _Shift = _x_208;
       const _x = _Shift._0;
-      if (_x_208.$tag === 1) {
-        const _Shift$2 = _x_208;
+      if (_x_209.$tag === 1) {
+        const _Shift$2 = _x_209;
         const _x$2 = _Shift$2._0;
         return _x === _x$2;
       } else {
@@ -14946,12 +14990,12 @@ function moonbitlang$core$builtin$$Eq$op_equal$59$(_x_207, _x_208) {
       }
     }
     case 2: {
-      const _Reduce = _x_207;
+      const _Reduce = _x_208;
       const _x$2 = _Reduce._0;
       const _x$3 = _Reduce._1;
       const _x$4 = _Reduce._2;
-      if (_x_208.$tag === 2) {
-        const _Reduce$2 = _x_208;
+      if (_x_209.$tag === 2) {
+        const _Reduce$2 = _x_209;
         const _x$5 = _Reduce$2._0;
         const _x$6 = _Reduce$2._1;
         const _x$7 = _Reduce$2._2;
@@ -14961,12 +15005,12 @@ function moonbitlang$core$builtin$$Eq$op_equal$59$(_x_207, _x_208) {
       }
     }
     default: {
-      const _ReduceNoLookahead = _x_207;
+      const _ReduceNoLookahead = _x_208;
       const _x$5 = _ReduceNoLookahead._0;
       const _x$6 = _ReduceNoLookahead._1;
       const _x$7 = _ReduceNoLookahead._2;
-      if (_x_208.$tag === 3) {
-        const _ReduceNoLookahead$2 = _x_208;
+      if (_x_209.$tag === 3) {
+        const _ReduceNoLookahead$2 = _x_209;
         const _x$8 = _ReduceNoLookahead$2._0;
         const _x$9 = _ReduceNoLookahead$2._1;
         const _x$10 = _ReduceNoLookahead$2._2;
@@ -14977,24 +15021,24 @@ function moonbitlang$core$builtin$$Eq$op_equal$59$(_x_207, _x_208) {
     }
   }
 }
-function moonbitlang$core$builtin$$Compare$compare$59$(_x_167, _x_168) {
-  switch (_x_167.$tag) {
+function moonbitlang$core$builtin$$Compare$compare$59$(_x_168, _x_169) {
+  switch (_x_168.$tag) {
     case 0: {
-      if (_x_168.$tag === 0) {
+      if (_x_169.$tag === 0) {
         return 0;
       } else {
         return -1;
       }
     }
     case 1: {
-      const _Shift = _x_167;
+      const _Shift = _x_168;
       const _x = _Shift._0;
-      switch (_x_168.$tag) {
+      switch (_x_169.$tag) {
         case 0: {
           return 1;
         }
         case 1: {
-          const _Shift$2 = _x_168;
+          const _Shift$2 = _x_169;
           const _x$2 = _Shift$2._0;
           return $compare_int(_x, _x$2);
         }
@@ -15004,11 +15048,11 @@ function moonbitlang$core$builtin$$Compare$compare$59$(_x_167, _x_168) {
       }
     }
     case 2: {
-      const _Reduce = _x_167;
+      const _Reduce = _x_168;
       const _x$3 = _Reduce._0;
       const _x$4 = _Reduce._1;
       const _x$5 = _Reduce._2;
-      switch (_x_168.$tag) {
+      switch (_x_169.$tag) {
         case 0: {
           return 1;
         }
@@ -15016,7 +15060,7 @@ function moonbitlang$core$builtin$$Compare$compare$59$(_x_167, _x_168) {
           return 1;
         }
         case 2: {
-          const _Reduce$2 = _x_168;
+          const _Reduce$2 = _x_169;
           const _x$6 = _Reduce$2._0;
           const _x$7 = _Reduce$2._1;
           const _x$8 = _Reduce$2._2;
@@ -15038,11 +15082,11 @@ function moonbitlang$core$builtin$$Compare$compare$59$(_x_167, _x_168) {
       }
     }
     default: {
-      const _ReduceNoLookahead = _x_167;
+      const _ReduceNoLookahead = _x_168;
       const _x$9 = _ReduceNoLookahead._0;
       const _x$10 = _ReduceNoLookahead._1;
       const _x$11 = _ReduceNoLookahead._2;
-      switch (_x_168.$tag) {
+      switch (_x_169.$tag) {
         case 0: {
           return 1;
         }
@@ -15053,7 +15097,7 @@ function moonbitlang$core$builtin$$Compare$compare$59$(_x_167, _x_168) {
           return 1;
         }
         default: {
-          const _ReduceNoLookahead$2 = _x_168;
+          const _ReduceNoLookahead$2 = _x_169;
           const _x$12 = _ReduceNoLookahead$2._0;
           const _x$13 = _ReduceNoLookahead$2._1;
           const _x$14 = _ReduceNoLookahead$2._2;
@@ -15073,43 +15117,48 @@ function moonbitlang$core$builtin$$Compare$compare$59$(_x_167, _x_168) {
     }
   }
 }
-function moonbitlang$yacc$lib$codegen$gen_mbt$$CodegenDecision$to_string(self) {
+function moonbitlang$core$builtin$$Show$output$59$(self, logger) {
+  let _tmp;
   switch (self.$tag) {
     case 0: {
-      return "Accept";
+      _tmp = "Accept";
+      break;
     }
     case 1: {
       const _Shift = self;
       const _x = _Shift._0;
-      return `Shift(yy_state_${moonbitlang$core$int$$Int$to_string(_x)})`;
+      _tmp = `Shift(yy_state_${moonbitlang$core$builtin$$Show$to_string$18$(_x)})`;
+      break;
     }
     case 2: {
       const _Reduce = self;
       const _x$2 = _Reduce._0;
       const _x$3 = _Reduce._1;
       const _x$4 = _Reduce._2;
-      return `Reduce(${moonbitlang$core$int$$Int$to_string(_x$2)}, NT_${_x$3}, yy_action_${moonbitlang$core$int$$Int$to_string(_x$4)})`;
+      _tmp = `Reduce(${moonbitlang$core$builtin$$Show$to_string$18$(_x$2)}, NT_${moonbitlang$core$builtin$$Show$to_string$10$(_x$3)}, yy_action_${moonbitlang$core$builtin$$Show$to_string$18$(_x$4)})`;
+      break;
     }
     default: {
       const _ReduceNoLookahead = self;
       const _x$5 = _ReduceNoLookahead._0;
       const _x$6 = _ReduceNoLookahead._1;
       const _x$7 = _ReduceNoLookahead._2;
-      return `ReduceNoLookahead(${moonbitlang$core$int$$Int$to_string(_x$5)}, NT_${_x$6}, yy_action_${moonbitlang$core$int$$Int$to_string(_x$7)})`;
+      _tmp = `ReduceNoLookahead(${moonbitlang$core$builtin$$Show$to_string$18$(_x$5)}, NT_${moonbitlang$core$builtin$$Show$to_string$10$(_x$6)}, yy_action_${moonbitlang$core$builtin$$Show$to_string$18$(_x$7)})`;
     }
   }
+  logger.method_0(logger.self, _tmp);
 }
 function moonbitlang$yacc$lib$codegen$gen_mbt$$esc(code) {
   return moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(moonbitlang$core$string$$String$replace_all(code, "@", "_"), "/", "_"), ".", "_"), "[", "_"), "]", "_"), "(", "_"), ")", "_"), ",", "_"), " ", "_"), "?", "_");
 }
-function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$inject_derive$173$(derive_map, type_) {
-  const _bind = moonbitlang$core$immut$hashmap$$T$op_get$49$(derive_map, type_);
+function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$inject_derive$184$(derive_map, type_) {
+  const _bind = moonbitlang$core$immut$hashmap$$T$op_get$50$(derive_map, type_);
   if (_bind === undefined) {
     return "";
   } else {
     const _Some = _bind;
     const _x = _Some;
-    return ` derive(${_x})`;
+    return ` derive(${moonbitlang$core$builtin$$Show$to_string$10$(_x)})`;
   }
 }
 function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, terminal_meta, output, no_comments, derive_map) {
@@ -15122,11 +15171,11 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, termina
       const term = terminals[_i];
       const _bind = terminal_meta(term.name).data_type;
       if (_bind === undefined) {
-        output.method_0(output.self, `  ${term.name}\n`);
+        output.method_0(output.self, `  ${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}\n`);
       } else {
         const _Some = _bind;
         const _x = _Some;
-        output.method_0(output.self, `  ${term.name}(${_x})\n`);
+        output.method_0(output.self, `  ${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}(${moonbitlang$core$builtin$$Show$to_string$10$(_x)})\n`);
       }
       _tmp = _i + 1 | 0;
       continue;
@@ -15134,7 +15183,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, termina
       break;
     }
   }
-  output.method_0(output.self, `}${moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$inject_derive$173$(derive_map, 0)}\n\npub fn Token::kind(self : Token) -> TokenKind {\n  match self {\n`);
+  output.method_0(output.self, `}${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$inject_derive$184$(derive_map, 0))}\n\npub fn Token::kind(self : Token) -> TokenKind {\n  match self {\n`);
   const _len$2 = terminals.length;
   let _tmp$2 = 0;
   while (true) {
@@ -15143,9 +15192,9 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, termina
       const term = terminals[_i];
       const _bind = terminal_meta(term.name).data_type;
       if (_bind === undefined) {
-        output.method_0(output.self, `    ${term.name} => TK_${term.name}\n`);
+        output.method_0(output.self, `    ${moonbitlang$core$builtin$$Show$to_string$10$(term.name)} => TK_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}\n`);
       } else {
-        output.method_0(output.self, `    ${term.name}(_) => TK_${term.name}\n`);
+        output.method_0(output.self, `    ${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}(_) => TK_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}\n`);
       }
       _tmp$2 = _i + 1 | 0;
       continue;
@@ -15161,14 +15210,14 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, termina
     const _i = _tmp$3;
     if (_i < _len$3) {
       const term = terminals[_i];
-      output.method_0(output.self, `  TK_${term.name}\n`);
+      output.method_0(output.self, `  TK_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}\n`);
       _tmp$3 = _i + 1 | 0;
       continue;
     } else {
       break;
     }
   }
-  output.method_0(output.self, `}${moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$inject_derive$173$(derive_map, 1)}\n\n`);
+  output.method_0(output.self, `}${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$inject_derive$184$(derive_map, 1))}\n\n`);
   output.method_0(output.self, "pub impl Show for TokenKind with output(self, logger) {\n  logger.write_string(\n    match self {\n");
   const _len$4 = terminals.length;
   let _tmp$4 = 0;
@@ -15185,7 +15234,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, termina
         const _x = _Some;
         name = _x;
       }
-      output.method_0(output.self, `      TK_${term.name} => ${moonbitlang$core$string$$String$escape(name)}\n`);
+      output.method_0(output.self, `      TK_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)} => ${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$core$string$$String$escape(name))}\n`);
       _tmp$4 = _i + 1 | 0;
       continue;
     } else {
@@ -15195,13 +15244,13 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, termina
   output.method_0(output.self, "    }\n  )\n}\n\n");
 }
 function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$derive_map$46$default() {
-  return moonbitlang$core$immut$hashmap$$new$49$();
+  return moonbitlang$core$immut$hashmap$$new$50$();
 }
-function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen$46$add_symbol_decision$174$(_env, symbol, decision) {
+function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen$46$add_symbol_decision$185$(_env, symbol, decision) {
   const grammar = _env._2;
   const decision_groups = _env._1;
   const sum = _env._0;
-  moonbitlang$core$sorted_map$$T$op_set$55$(decision_groups, decision, moonbitlang$core$immut$sorted_set$$T$add$38$(moonbitlang$core$option$$Option$or$39$(moonbitlang$core$sorted_map$$T$op_get$55$(decision_groups, decision), moonbitlang$core$immut$sorted_set$$new$38$()), symbol));
+  moonbitlang$core$sorted_map$$T$op_set$55$(decision_groups, decision, moonbitlang$core$immut$sorted_set$$T$add$39$(moonbitlang$core$option$$Option$or$40$(moonbitlang$core$sorted_map$$T$op_get$55$(decision_groups, decision), moonbitlang$core$immut$sorted_set$$new$39$()), symbol));
   switch (symbol.$tag) {
     case 0: {
       const _T = symbol;
@@ -15226,27 +15275,27 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
   const _x = meta.terminal_meta;
   const _x$2 = meta.nonterminal_meta;
   const _x$3 = meta.production_meta;
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, meta.header);
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, `pub(all) typealias Position = ${meta.position_data_type}\n\n`);
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, meta.header);
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, `pub(all) typealias Position = ${moonbitlang$core$builtin$$Show$to_string$10$(meta.position_data_type)}\n\n`);
   if (external_tokens) {
   } else {
-    moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(grammar.terminals, _x, { self: output, method_0: moonbitlang$core$builtin$$Logger$write_string$148$, method_1: moonbitlang$core$builtin$$Logger$write_substring$148$, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$147$, method_3: moonbitlang$core$builtin$$Logger$write_char$148$ }, no_comments, meta.derive_map);
+    moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(grammar.terminals, _x, { self: output, method_0: moonbitlang$core$builtin$$Logger$write_string$159$, method_1: moonbitlang$core$builtin$$Logger$write_substring$159$, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$158$, method_3: moonbitlang$core$builtin$$Logger$write_char$159$ }, no_comments, meta.derive_map);
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "pub type! ParseError {\n  UnexpectedToken(Token, (Position, Position), Array[TokenKind])\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "pub type! ParseError {\n  UnexpectedToken(Token, (Position, Position), Array[TokenKind])\n");
   if (input_mode === 0) {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "  UnexpectedEndOfInput(Position, Array[TokenKind])\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "  UnexpectedEndOfInput(Position, Array[TokenKind])\n");
   }
-  const _bind = moonbitlang$core$immut$hashmap$$T$op_get$49$(meta.derive_map, 2);
+  const _bind = moonbitlang$core$immut$hashmap$$T$op_get$50$(meta.derive_map, 2);
   let _tmp;
   if (_bind === undefined) {
     _tmp = "";
   } else {
     const _Some = _bind;
     const _x$4 = _Some;
-    _tmp = ` derive(${_x$4})`;
+    _tmp = ` derive(${moonbitlang$core$builtin$$Show$to_string$10$(_x$4)})`;
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, `}${_tmp}\n\n`);
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "typealias YYObj = Error\n\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, `}${moonbitlang$core$builtin$$Show$to_string$10$(_tmp)}\n\n`);
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "typealias YYObj = Error\n\n");
   if (mode.$tag === 0) {
     const data_types = moonbitlang$core$sorted_set$$new$10$();
     const _arr = grammar.terminals;
@@ -15278,8 +15327,8 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
       if (_i < _len$2) {
         _L: {
           const nonterm = _arr$2[_i];
-          const _bind$2 = moonbitlang$core$array$$Array$iter$32$(grammar.starts);
-          if (!moonbitlang$core$builtin$$Iter$contains$18$((_p) => _bind$2((_p$2) => _p(_p$2.lhs)), nonterm)) {
+          const _bind$2 = moonbitlang$core$array$$Array$iter$33$(grammar.starts);
+          if (!moonbitlang$core$builtin$$Iter$contains$96$((_p) => _bind$2((_p$2) => _p(_p$2.lhs)), nonterm)) {
             const meta$2 = _x$2(nonterm.name);
             moonbitlang$core$sorted_set$$T$add$10$(data_types, meta$2.data_type);
           } else {
@@ -15293,17 +15342,17 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
         break;
       }
     }
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "priv type! YYObj_Void\n\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "priv type! YYObj_Void\n\n");
     const _bind$2 = moonbitlang$core$sorted_set$$T$iter$10$(data_types);
     _bind$2((data_type) => {
-      moonbitlang$core$builtin$$Logger$write_string$148$(output, `priv type! YYObj_${moonbitlang$yacc$lib$codegen$gen_mbt$$esc(data_type)} ${data_type}\n\n`);
+      moonbitlang$core$builtin$$Logger$write_string$159$(output, `priv type! YYObj_${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$yacc$lib$codegen$gen_mbt$$esc(data_type))} ${moonbitlang$core$builtin$$Show$to_string$10$(data_type)}\n\n`);
       return 1;
     });
   } else {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "type! YYObj_Json Json\n\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "type! YYObj_Json Json\n\n");
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "typealias YYState = (YYSymbol) -> YYDecision\n\ntypealias YYAction = (Position, ArrayView[(YYObj, Position, Position)]) -> YYObj\n\npriv enum YYDecision {\n  Accept\n  Shift(YYState)\n  Reduce(Int, YYSymbol, YYAction)\n  ReduceNoLookahead(Int, YYSymbol, YYAction)\n  Error\n}\n\n");
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "priv enum YYSymbol {\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "typealias YYState = (YYSymbol) -> YYDecision\n\ntypealias YYAction = (Position, ArrayView[(YYObj, Position, Position)]) -> YYObj\n\npriv enum YYDecision {\n  Accept\n  Shift(YYState)\n  Reduce(Int, YYSymbol, YYAction)\n  ReduceNoLookahead(Int, YYSymbol, YYAction)\n  Error\n}\n\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "priv enum YYSymbol {\n");
   const _arr = grammar.terminals;
   const _len = _arr.length;
   let _tmp$2 = 0;
@@ -15311,7 +15360,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
     const _i = _tmp$2;
     if (_i < _len) {
       const term = _arr[_i];
-      moonbitlang$core$builtin$$Logger$write_string$148$(output, `  T_${term.name}\n`);
+      moonbitlang$core$builtin$$Logger$write_string$159$(output, `  T_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}\n`);
       _tmp$2 = _i + 1 | 0;
       continue;
     } else {
@@ -15326,9 +15375,9 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
     if (_i < _len$2) {
       _L: {
         const nonterm = _arr$2[_i];
-        const _bind$2 = moonbitlang$core$array$$Array$iter$32$(grammar.starts);
-        if (!moonbitlang$core$builtin$$Iter$contains$18$((_p) => _bind$2((_p$2) => _p(_p$2.lhs)), nonterm)) {
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, `  NT_${nonterm.name}\n`);
+        const _bind$2 = moonbitlang$core$array$$Array$iter$33$(grammar.starts);
+        if (!moonbitlang$core$builtin$$Iter$contains$96$((_p) => _bind$2((_p$2) => _p(_p$2.lhs)), nonterm)) {
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, `  NT_${moonbitlang$core$builtin$$Show$to_string$10$(nonterm.name)}\n`);
         } else {
           break _L;
         }
@@ -15340,7 +15389,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
       break;
     }
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "  EOI\n}\n\n// Workaround for EOI unused warning\nfn init {\n  match EOI {\n    EOI => ()\n    _ => ()\n  }\n}\n\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "  EOI\n}\n\n// Workaround for EOI unused warning\nfn init {\n  match EOI {\n    EOI => ()\n    _ => ()\n  }\n}\n\n");
   const _arr$3 = grammar.productions;
   const _len$3 = _arr$3.length;
   let _tmp$4 = 0;
@@ -15349,9 +15398,9 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
     if (_i < _len$3) {
       _L: {
         const production = _arr$3[_i];
-        if (!moonbitlang$core$array$$Array$contains$32$(grammar.starts, production)) {
+        if (!moonbitlang$core$array$$Array$contains$33$(grammar.starts, production)) {
           const meta$2 = _x$3(production.num);
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, `fn yy_action_${moonbitlang$core$int$$Int$to_string(production.num)}(_last_pos : Position, _args : ArrayView[(YYObj, Position, Position)]) -> YYObj {\n`);
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, `fn yy_action_${moonbitlang$core$builtin$$Show$to_string$18$(production.num)}(_last_pos : Position, _args : ArrayView[(YYObj, Position, Position)]) -> YYObj {\n`);
           const _arr$4 = meta$2.bindings;
           const _len$4 = _arr$4.length;
           let _tmp$5 = 0;
@@ -15378,11 +15427,11 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
                         const _x$5 = _NT._0;
                         data_type = _x$2(_x$5.name).data_type;
                       }
-                      moonbitlang$core$builtin$$Logger$write_string$148$(output, `  guard let YYObj_${moonbitlang$yacc$lib$codegen$gen_mbt$$esc(data_type)}(${binding._1}) = _args[${moonbitlang$core$int$$Int$to_string(_x$4)}].0\n`);
+                      moonbitlang$core$builtin$$Logger$write_string$159$(output, `  guard let YYObj_${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$yacc$lib$codegen$gen_mbt$$esc(data_type))}(${moonbitlang$core$builtin$$Show$to_string$10$(binding._1)}) = _args[${moonbitlang$core$builtin$$Show$to_string$18$(_x$4)}].0\n`);
                       break;
                     }
                     case 1: {
-                      moonbitlang$core$builtin$$Logger$write_string$148$(output, `  let ${binding._1} = _last_pos\n`);
+                      moonbitlang$core$builtin$$Logger$write_string$159$(output, `  let ${moonbitlang$core$builtin$$Show$to_string$10$(binding._1)} = _last_pos\n`);
                       break;
                     }
                     case 2: {
@@ -15399,13 +15448,13 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
                     }
                     default: {
                       moonbitlang$core$sorted_set$$T$add$10$(used_runtime_funcs, "_get_symbol_start_pos");
-                      moonbitlang$core$builtin$$Logger$write_string$148$(output, `  let ${binding._1} = _get_symbol_start_pos(_args, _last_pos)\n`);
+                      moonbitlang$core$builtin$$Logger$write_string$159$(output, `  let ${moonbitlang$core$builtin$$Show$to_string$10$(binding._1)} = _get_symbol_start_pos(_args, _last_pos)\n`);
                     }
                   }
                   break _L$2;
                 }
                 if (production.rhs.length === 0) {
-                  moonbitlang$core$builtin$$Logger$write_string$148$(output, `  let ${binding._1} = _last_pos\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$159$(output, `  let ${moonbitlang$core$builtin$$Show$to_string$10$(binding._1)} = _last_pos\n`);
                 } else {
                   const _bind$2 = binding._0;
                   let field;
@@ -15422,7 +15471,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
                       field = $panic();
                     }
                   }
-                  moonbitlang$core$builtin$$Logger$write_string$148$(output, `  let ${binding._1} = _args[${moonbitlang$core$int$$Int$to_string(index)}].${moonbitlang$core$int$$Int$to_string(field)}\n`);
+                  moonbitlang$core$builtin$$Logger$write_string$159$(output, `  let ${moonbitlang$core$builtin$$Show$to_string$10$(binding._1)} = _args[${moonbitlang$core$builtin$$Show$to_string$18$(index)}].${moonbitlang$core$builtin$$Show$to_string$18$(field)}\n`);
                 }
               }
               _tmp$5 = _i$2 + 1 | 0;
@@ -15431,7 +15480,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
               break;
             }
           }
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, `  YYObj_${moonbitlang$yacc$lib$codegen$gen_mbt$$esc(_x$2(production.lhs.name).data_type)}({(); `);
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, `  YYObj_${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$yacc$lib$codegen$gen_mbt$$esc(_x$2(production.lhs.name).data_type))}({(); `);
           const _arr$5 = meta$2.body;
           const _len$5 = _arr$5.length;
           let _tmp$6 = 0;
@@ -15453,15 +15502,15 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
                   _x$7.method_0(_x$7.self, grammar_filename, _x$6, generated_utf8_pos, _x$4.length);
                 }
               }
-              moonbitlang$core$builtin$$Logger$write_string$148$(output, _x$4);
+              moonbitlang$core$builtin$$Logger$write_string$159$(output, _x$4);
               _tmp$6 = _i$2 + 1 | 0;
               continue;
             } else {
               break;
             }
           }
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, "})\n");
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, "}\n\n");
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, "})\n");
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, "}\n\n");
         } else {
           break _L;
         }
@@ -15473,7 +15522,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
       break;
     }
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "fn yy_input(token : Token, _start_pos : Position, _end_pos : Position) -> (YYSymbol, YYObj) {\n  match token {\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "fn yy_input(token : Token, _start_pos : Position, _end_pos : Position) -> (YYSymbol, YYObj) {\n  match token {\n");
   const _arr$4 = grammar.terminals;
   const _len$4 = _arr$4.length;
   let _tmp$5 = 0;
@@ -15485,18 +15534,18 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
       if (mode.$tag === 0) {
         const _bind$2 = meta$2.data_type;
         if (_bind$2 === undefined) {
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, `    ${term.name} => (T_${term.name}, YYObj_Void)\n`);
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, `    ${moonbitlang$core$builtin$$Show$to_string$10$(term.name)} => (T_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}, YYObj_Void)\n`);
         } else {
           const _Some = _bind$2;
           const _x$4 = _Some;
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, `    ${term.name}(data) => (T_${term.name}, YYObj_${moonbitlang$yacc$lib$codegen$gen_mbt$$esc(_x$4)}(data))\n`);
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, `    ${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}(data) => (T_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}, YYObj_${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$yacc$lib$codegen$gen_mbt$$esc(_x$4))}(data))\n`);
         }
       } else {
         const _bind$2 = meta$2.data_type;
         const payload_code = _bind$2 === undefined ? "" : "(data)";
         const _bind$3 = meta$2.data_type;
         const data_code = _bind$3 === undefined ? "Null" : "data.to_json()";
-        moonbitlang$core$builtin$$Logger$write_string$148$(output, `    ${term.name}${payload_code} => (T_${term.name}, YYObj_Json({\n      \"type\": \"TERMINAL\",\n      \"name\": \"${term.name}\",\n      \"data\": ${data_code},\n      \"start\": _start_pos.to_json(),\n      \"end\": _end_pos.to_json()\n    }))\n`);
+        moonbitlang$core$builtin$$Logger$write_string$159$(output, `    ${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}${moonbitlang$core$builtin$$Show$to_string$10$(payload_code)} => (T_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}, YYObj_Json({\n      \"type\": \"TERMINAL\",\n      \"name\": \"${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}\",\n      \"data\": ${moonbitlang$core$builtin$$Show$to_string$10$(data_code)},\n      \"start\": _start_pos.to_json(),\n      \"end\": _end_pos.to_json()\n    }))\n`);
       }
       _tmp$5 = _i + 1 | 0;
       continue;
@@ -15504,7 +15553,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
       break;
     }
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "  }\n}\n\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "  }\n}\n\n");
   const _arr$5 = automaton.states;
   const _len$5 = _arr$5.length;
   let _tmp$6 = 0;
@@ -15515,11 +15564,11 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
       if (!no_comments) {
         const _bind$2 = moonbitlang$yacc$lib$lr1$$LR1State$iter_item_groups(state);
         _bind$2((item) => {
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, `// ${moonbitlang$core$builtin$$Show$to_string$150$(item)}\n`);
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, `// ${moonbitlang$core$builtin$$Show$to_string$162$(item)}\n`);
           return 1;
         });
       }
-      moonbitlang$core$builtin$$Logger$write_string$148$(output, `fn yy_state_${moonbitlang$core$int$$Int$to_string(state.num)}(_lookahead : YYSymbol) -> YYDecision {\n`);
+      moonbitlang$core$builtin$$Logger$write_string$159$(output, `fn yy_state_${moonbitlang$core$builtin$$Show$to_string$18$(state.num)}(_lookahead : YYSymbol) -> YYDecision {\n`);
       const sum = { val: 0 };
       const decision_groups = moonbitlang$core$sorted_map$$new$55$();
       const _env = { _0: sum, _1: decision_groups, _2: grammar };
@@ -15556,7 +15605,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
             _tmp$9 = $panic();
           }
         }
-        moonbitlang$yacc$lib$codegen$gen_mbt$$codegen$46$add_symbol_decision$174$(_env, _tmp$8, _tmp$9);
+        moonbitlang$yacc$lib$codegen$gen_mbt$$codegen$46$add_symbol_decision$185$(_env, _tmp$8, _tmp$9);
         return 1;
       });
       const _bind$3 = moonbitlang$core$sorted_map$$T$iter2$56$(state.goto);
@@ -15564,7 +15613,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
         if (symbol.$tag === 1) {
           const _NT = symbol;
           const _x$4 = _NT._0;
-          moonbitlang$yacc$lib$codegen$gen_mbt$$codegen$46$add_symbol_decision$174$(_env, new $64$moonbitlang$47$yacc$47$lib$47$codegen$47$gen_mbt$46$CodegenSymbol$NT(_x$4.num, _x$4.name), new $64$moonbitlang$47$yacc$47$lib$47$codegen$47$gen_mbt$46$CodegenDecision$Shift(state$2.num));
+          moonbitlang$yacc$lib$codegen$gen_mbt$$codegen$46$add_symbol_decision$185$(_env, new $64$moonbitlang$47$yacc$47$lib$47$codegen$47$gen_mbt$46$CodegenSymbol$NT(_x$4.num, _x$4.name), new $64$moonbitlang$47$yacc$47$lib$47$codegen$47$gen_mbt$46$CodegenDecision$Shift(state$2.num));
         }
         return 1;
       });
@@ -15631,23 +15680,23 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
         } else {
           decision$2 = decision;
         }
-        moonbitlang$core$builtin$$Logger$write_string$148$(output, `  ${moonbitlang$yacc$lib$codegen$gen_mbt$$CodegenDecision$to_string(decision$2)}\n`);
+        moonbitlang$core$builtin$$Logger$write_string$159$(output, `  ${moonbitlang$core$builtin$$Show$to_string$161$(decision$2)}\n`);
       } else {
-        moonbitlang$core$builtin$$Logger$write_string$148$(output, "  match _lookahead {\n");
+        moonbitlang$core$builtin$$Logger$write_string$159$(output, "  match _lookahead {\n");
         const _bind$4 = moonbitlang$core$sorted_map$$T$iter2$55$(decision_groups);
         _bind$4((decision, symbols) => {
-          const _bind$5 = moonbitlang$core$immut$sorted_set$$T$iter$38$(symbols);
+          const _bind$5 = moonbitlang$core$immut$sorted_set$$T$iter$39$(symbols);
           const pattern = moonbitlang$core$string$$String$concat(moonbitlang$core$builtin$$Iter$to_array$10$((_p) => _bind$5((_p$2) => _p(moonbitlang$yacc$lib$codegen$gen_mbt$$CodegenSymbol$to_string(_p$2)))), " | ");
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, `    ${pattern} => ${moonbitlang$yacc$lib$codegen$gen_mbt$$CodegenDecision$to_string(decision)}\n`);
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, `    ${moonbitlang$core$builtin$$Show$to_string$10$(pattern)} => ${moonbitlang$core$builtin$$Show$to_string$161$(decision)}\n`);
           return 1;
         });
         const exhaustive = sum.val === total;
         if (!exhaustive) {
-          moonbitlang$core$builtin$$Logger$write_string$148$(output, "    _ => Error\n");
+          moonbitlang$core$builtin$$Logger$write_string$159$(output, "    _ => Error\n");
         }
-        moonbitlang$core$builtin$$Logger$write_string$148$(output, "  }\n");
+        moonbitlang$core$builtin$$Logger$write_string$159$(output, "  }\n");
       }
-      moonbitlang$core$builtin$$Logger$write_string$148$(output, "}\n\n");
+      moonbitlang$core$builtin$$Logger$write_string$159$(output, "}\n\n");
       _tmp$6 = _i + 1 | 0;
       continue;
     } else {
@@ -15655,17 +15704,17 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
     }
   }
   if (input_mode === 0) {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "fn yy_parse[T](\n  tokens : Array[(Token, Position, Position)],\n  start : YYState,\n  return_ : (YYObj) -> T\n) -> T!ParseError {\n  let mut cursor = 0\n  let mut state_stack : @immut/list.T[YYState] = Cons(start, Nil)\n  let data_stack : Array[(YYObj, Position, Position)] = []\n  let mut last_pos = tokens[0].1\n  let mut state = start\n  let mut lookahead : Option[(YYSymbol, (YYObj, Position, Position), Token?)] = None\n  let mut last_shifted_state_stack = state_stack\n  while true {\n    let decision = match state(EOI) {\n      ReduceNoLookahead(_) | Accept as t => t\n      _ => {\n        match lookahead {\n          Some(la) => state(la.0)\n          None => {\n            if cursor < tokens.length() {\n              let (token, start_pos, end_pos) = tokens[cursor]\n              cursor += 1\n              let (symbol, data) = yy_input(token, start_pos, end_pos)\n              lookahead = Some((symbol, (data, start_pos, end_pos), Some(token)))\n              state(symbol)\n            } else {\n              lookahead = Some((EOI, (YYObj_Void, last_pos, last_pos), None))\n              state(EOI)\n            }\n          }\n        }\n      }\n    }\n    match decision {\n      Accept => return return_(data_stack.unsafe_pop().0)\n      Shift(next_state) => {\n        guard let Some(la) = lookahead\n        data_stack.push(la.1)\n        state_stack = Cons(next_state, state_stack)\n        last_shifted_state_stack = state_stack\n        state = next_state\n        last_pos = la.1.2\n        lookahead = None\n      }\n      Reduce(count, symbol, action)\n      | ReduceNoLookahead(count, symbol, action) => {\n        loop (count, symbol, action) {\n          _ => {\n            let args = data_stack[data_stack.length() - count:]\n            let data = action(last_pos, args)\n            let (start_pos, end_pos) = if args.length() == 0 {\n              (last_pos, last_pos)\n            } else {\n              (args[0].1, args[args.length() - 1].2)\n            }\n            for i in 0..<count {\n              ignore(data_stack.unsafe_pop())\n              state_stack = state_stack.tail()\n            }\n            state = state_stack.unsafe_head()\n            data_stack.push((data, start_pos, end_pos))\n            match state(symbol) {\n              Accept => return return_(data_stack.unsafe_pop().0)\n              Shift(next_state) => {\n                state_stack = Cons(next_state, state_stack)\n                state = next_state\n              }\n              Reduce(count, symbol, action)\n              | ReduceNoLookahead(count, symbol, action) => continue (count, symbol, action)\n              _ => panic()\n            }\n          }\n        }\n      }\n      Error => {\n        let (_, (_, start_pos, end_pos), token) = lookahead.unwrap()\n        error!(last_shifted_state_stack, token, (start_pos, end_pos))\n      }\n    }\n  }\n  panic()\n}\n\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "fn yy_parse[T](\n  tokens : Array[(Token, Position, Position)],\n  start : YYState,\n  return_ : (YYObj) -> T\n) -> T!ParseError {\n  let mut cursor = 0\n  let mut state_stack : @immut/list.T[YYState] = Cons(start, Nil)\n  let data_stack : Array[(YYObj, Position, Position)] = []\n  let mut last_pos = tokens[0].1\n  let mut state = start\n  let mut lookahead : Option[(YYSymbol, (YYObj, Position, Position), Token?)] = None\n  let mut last_shifted_state_stack = state_stack\n  while true {\n    let decision = match state(EOI) {\n      ReduceNoLookahead(_) | Accept as t => t\n      _ => {\n        match lookahead {\n          Some(la) => state(la.0)\n          None => {\n            if cursor < tokens.length() {\n              let (token, start_pos, end_pos) = tokens[cursor]\n              cursor += 1\n              let (symbol, data) = yy_input(token, start_pos, end_pos)\n              lookahead = Some((symbol, (data, start_pos, end_pos), Some(token)))\n              state(symbol)\n            } else {\n              lookahead = Some((EOI, (YYObj_Void, last_pos, last_pos), None))\n              state(EOI)\n            }\n          }\n        }\n      }\n    }\n    match decision {\n      Accept => return return_(data_stack.unsafe_pop().0)\n      Shift(next_state) => {\n        guard let Some(la) = lookahead\n        data_stack.push(la.1)\n        state_stack = Cons(next_state, state_stack)\n        last_shifted_state_stack = state_stack\n        state = next_state\n        last_pos = la.1.2\n        lookahead = None\n      }\n      Reduce(count, symbol, action)\n      | ReduceNoLookahead(count, symbol, action) => {\n        loop (count, symbol, action) {\n          _ => {\n            let args = data_stack[data_stack.length() - count:]\n            let data = action(last_pos, args)\n            let (start_pos, end_pos) = if args.length() == 0 {\n              (last_pos, last_pos)\n            } else {\n              (args[0].1, args[args.length() - 1].2)\n            }\n            for i in 0..<count {\n              ignore(data_stack.unsafe_pop())\n              state_stack = state_stack.tail()\n            }\n            state = state_stack.unsafe_head()\n            data_stack.push((data, start_pos, end_pos))\n            match state(symbol) {\n              Accept => return return_(data_stack.unsafe_pop().0)\n              Shift(next_state) => {\n                state_stack = Cons(next_state, state_stack)\n                state = next_state\n              }\n              Reduce(count, symbol, action)\n              | ReduceNoLookahead(count, symbol, action) => continue (count, symbol, action)\n              _ => panic()\n            }\n          }\n        }\n      }\n      Error => {\n        let (_, (_, start_pos, end_pos), token) = lookahead.unwrap()\n        error!(last_shifted_state_stack, token, (start_pos, end_pos))\n      }\n    }\n  }\n  panic()\n}\n\n");
   } else {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "fn yy_parse[T](\n  read_token : () -> (Token, Position, Position),\n  start_pos : Position,\n  start : YYState,\n  return_ : (YYObj) -> T\n) -> T!ParseError {\n  let mut state_stack : @immut/list.T[YYState] = Cons(start, Nil)\n  let data_stack : Array[(YYObj, Position, Position)] = []\n  let mut last_pos = start_pos\n  let mut state = start\n  let mut lookahead : Option[(YYSymbol, (YYObj, Position, Position), Token)] = None\n  let mut last_shifted_state_stack = state_stack\n  while true {\n    let decision = match state(EOI) {\n      ReduceNoLookahead(_) | Accept as t => t\n      _ => {\n        match lookahead {\n          Some(la) => state(la.0)\n          None => {\n            let (token, start_pos, end_pos) = read_token()\n            let (symbol, data) = yy_input(token, start_pos, end_pos)\n            lookahead = Some((symbol, (data, start_pos, end_pos), token))\n            state(symbol)\n          }\n        }\n      }\n    }\n    match decision {\n      Accept => return return_(data_stack.unsafe_pop().0)\n      Shift(next_state) => {\n        guard let Some(la) = lookahead\n        data_stack.push(la.1)\n        state_stack = Cons(next_state, state_stack)\n        last_shifted_state_stack = state_stack\n        state = next_state\n        last_pos = la.1.2\n        lookahead = None\n      }\n      Reduce(count, symbol, action)\n      | ReduceNoLookahead(count, symbol, action) => {\n        loop (count, symbol, action) {\n          _ => {\n            let args = data_stack[data_stack.length() - count:]\n            let data = action(last_pos, args)\n            let (start_pos, end_pos) = if args.length() == 0 {\n              (last_pos, last_pos)\n            } else {\n              (args[0].1, args[args.length() - 1].2)\n            }\n            for i in 0..<count {\n              ignore(data_stack.unsafe_pop())\n              state_stack = state_stack.tail()\n            }\n            state = state_stack.unsafe_head()\n            data_stack.push((data, start_pos, end_pos))\n            match state(symbol) {\n              Accept => return return_(data_stack.unsafe_pop().0)\n              Shift(next_state) => {\n                state_stack = Cons(next_state, state_stack)\n                state = next_state\n              }\n              Reduce(count, symbol, action)\n              | ReduceNoLookahead(count, symbol, action) => continue (count, symbol, action)\n              _ => panic()\n            }\n          }\n        }\n      }\n      Error => {\n        let (_, (_, start_pos, end_pos), token) = lookahead.unwrap()\n        error!(last_shifted_state_stack, token, (start_pos, end_pos))\n      }\n    }\n  }\n  panic()\n}\n\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "fn yy_parse[T](\n  read_token : () -> (Token, Position, Position),\n  start_pos : Position,\n  start : YYState,\n  return_ : (YYObj) -> T\n) -> T!ParseError {\n  let mut state_stack : @immut/list.T[YYState] = Cons(start, Nil)\n  let data_stack : Array[(YYObj, Position, Position)] = []\n  let mut last_pos = start_pos\n  let mut state = start\n  let mut lookahead : Option[(YYSymbol, (YYObj, Position, Position), Token)] = None\n  let mut last_shifted_state_stack = state_stack\n  while true {\n    let decision = match state(EOI) {\n      ReduceNoLookahead(_) | Accept as t => t\n      _ => {\n        match lookahead {\n          Some(la) => state(la.0)\n          None => {\n            let (token, start_pos, end_pos) = read_token()\n            let (symbol, data) = yy_input(token, start_pos, end_pos)\n            lookahead = Some((symbol, (data, start_pos, end_pos), token))\n            state(symbol)\n          }\n        }\n      }\n    }\n    match decision {\n      Accept => return return_(data_stack.unsafe_pop().0)\n      Shift(next_state) => {\n        guard let Some(la) = lookahead\n        data_stack.push(la.1)\n        state_stack = Cons(next_state, state_stack)\n        last_shifted_state_stack = state_stack\n        state = next_state\n        last_pos = la.1.2\n        lookahead = None\n      }\n      Reduce(count, symbol, action)\n      | ReduceNoLookahead(count, symbol, action) => {\n        loop (count, symbol, action) {\n          _ => {\n            let args = data_stack[data_stack.length() - count:]\n            let data = action(last_pos, args)\n            let (start_pos, end_pos) = if args.length() == 0 {\n              (last_pos, last_pos)\n            } else {\n              (args[0].1, args[args.length() - 1].2)\n            }\n            for i in 0..<count {\n              ignore(data_stack.unsafe_pop())\n              state_stack = state_stack.tail()\n            }\n            state = state_stack.unsafe_head()\n            data_stack.push((data, start_pos, end_pos))\n            match state(symbol) {\n              Accept => return return_(data_stack.unsafe_pop().0)\n              Shift(next_state) => {\n                state_stack = Cons(next_state, state_stack)\n                state = next_state\n              }\n              Reduce(count, symbol, action)\n              | ReduceNoLookahead(count, symbol, action) => continue (count, symbol, action)\n              _ => panic()\n            }\n          }\n        }\n      }\n      Error => {\n        let (_, (_, start_pos, end_pos), token) = lookahead.unwrap()\n        error!(last_shifted_state_stack, token, (start_pos, end_pos))\n      }\n    }\n  }\n  panic()\n}\n\n");
   }
   if (input_mode === 0) {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "fn error(stack : @immut/list.T[YYState], token : Token?, loc : (Position, Position)) -> Unit!ParseError {\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "fn error(stack : @immut/list.T[YYState], token : Token?, loc : (Position, Position)) -> Unit!ParseError {\n");
   } else {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "fn error(stack : @immut/list.T[YYState], token : Token, loc : (Position, Position)) -> Unit!ParseError {\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "fn error(stack : @immut/list.T[YYState], token : Token, loc : (Position, Position)) -> Unit!ParseError {\n");
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "  let expected = []\n  fn try_add(symbol : YYSymbol, kind : TokenKind) {\n    fn go(stack : @immut/list.T[YYState]) {\n      match stack {\n        Nil => ()\n        Cons(state, _) => {\n          match state(symbol) {\n            Accept | Shift(_) => expected.push(kind)\n            Reduce(count, symbol, _) | ReduceNoLookahead(count, symbol, _) => {\n              fn inner_go(stack : @immut/list.T[YYState], count, symbol) {\n                let stack = stack.drop(count)\n                guard let Cons(state, _) = stack\n                match state(symbol) {\n                  Shift(state) => go(Cons(state, stack))\n                  Reduce(count, symbol, _) | ReduceNoLookahead(count, symbol, _) => inner_go(stack, count, symbol)\n                  _ => panic()\n                }\n              }\n              inner_go(stack, count, symbol)\n            }\n            Error => ()\n          }\n        }\n      }\n    }\n    go(stack)\n  }\n");
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "  for term in ([");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "  let expected = []\n  fn try_add(symbol : YYSymbol, kind : TokenKind) {\n    fn go(stack : @immut/list.T[YYState]) {\n      match stack {\n        Nil => ()\n        Cons(state, _) => {\n          match state(symbol) {\n            Accept | Shift(_) => expected.push(kind)\n            Reduce(count, symbol, _) | ReduceNoLookahead(count, symbol, _) => {\n              fn inner_go(stack : @immut/list.T[YYState], count, symbol) {\n                let stack = stack.drop(count)\n                guard let Cons(state, _) = stack\n                match state(symbol) {\n                  Shift(state) => go(Cons(state, stack))\n                  Reduce(count, symbol, _) | ReduceNoLookahead(count, symbol, _) => inner_go(stack, count, symbol)\n                  _ => panic()\n                }\n              }\n              inner_go(stack, count, symbol)\n            }\n            Error => ()\n          }\n        }\n      }\n    }\n    go(stack)\n  }\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "  for term in ([");
   const _arr$6 = grammar.terminals;
   const _len$6 = _arr$6.length;
   let _tmp$7 = 0;
@@ -15674,23 +15723,23 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
     if (_i < _len$6) {
       const term = _arr$6[_i];
       if (_i > 0) {
-        moonbitlang$core$builtin$$Logger$write_string$148$(output, ", ");
+        moonbitlang$core$builtin$$Logger$write_string$159$(output, ", ");
       }
-      moonbitlang$core$builtin$$Logger$write_string$148$(output, `(T_${term.name}, TK_${term.name})`);
+      moonbitlang$core$builtin$$Logger$write_string$159$(output, `(T_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)}, TK_${moonbitlang$core$builtin$$Show$to_string$10$(term.name)})`);
       _tmp$7 = _i + 1 | 0;
       continue;
     } else {
       break;
     }
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "] : Array[(YYSymbol, TokenKind)]) {\n");
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "    try_add(term.0, term.1)\n  }\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "] : Array[(YYSymbol, TokenKind)]) {\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "    try_add(term.0, term.1)\n  }\n");
   if (input_mode === 0) {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "  match token {\n    None => raise UnexpectedEndOfInput(loc.1, expected)\n    Some(token) => raise UnexpectedToken(token, loc, expected)\n  }\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "  match token {\n    None => raise UnexpectedEndOfInput(loc.1, expected)\n    Some(token) => raise UnexpectedToken(token, loc, expected)\n  }\n");
   } else {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "  raise UnexpectedToken(token, loc, expected)\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "  raise UnexpectedToken(token, loc, expected)\n");
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, "}\n\n");
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, "}\n\n");
   const _arr$7 = automaton.starts;
   const _len$7 = _arr$7.length;
   let _tmp$8 = 0;
@@ -15703,9 +15752,9 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
       const name = _x$4.lhs.name;
       const original_name = moonbitlang$core$string$$String$substring(name, 0, name.length - "_prime".length | 0);
       if (input_mode === 0) {
-        moonbitlang$core$builtin$$Logger$write_string$148$(output, `pub fn ${original_name}(tokens: Array[(Token, Position, Position)]) -> ${_x$2(name).data_type}!ParseError {\n  yy_parse!(\n    tokens,\n    yy_state_${moonbitlang$core$int$$Int$to_string(_x$5.num)},\n    fn {\n      YYObj_${moonbitlang$yacc$lib$codegen$gen_mbt$$esc(_x$2(name).data_type)}(result) => result\n      _ => panic()\n    },\n  )\n}\n`);
+        moonbitlang$core$builtin$$Logger$write_string$159$(output, `pub fn ${moonbitlang$core$builtin$$Show$to_string$10$(original_name)}(tokens: Array[(Token, Position, Position)]) -> ${moonbitlang$core$builtin$$Show$to_string$10$(_x$2(name).data_type)}!ParseError {\n  yy_parse!(\n    tokens,\n    yy_state_${moonbitlang$core$builtin$$Show$to_string$18$(_x$5.num)},\n    fn {\n      YYObj_${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$yacc$lib$codegen$gen_mbt$$esc(_x$2(name).data_type))}(result) => result\n      _ => panic()\n    },\n  )\n}\n`);
       } else {
-        moonbitlang$core$builtin$$Logger$write_string$148$(output, `pub fn ${original_name}(read_token : () -> (Token, Position, Position), start_pos : Position) -> ${_x$2(name).data_type}!ParseError {\n  yy_parse!(\n    read_token,\n    start_pos,\n    yy_state_${moonbitlang$core$int$$Int$to_string(_x$5.num)},\n    fn {\n      YYObj_${moonbitlang$yacc$lib$codegen$gen_mbt$$esc(_x$2(name).data_type)}(result) => result\n      _ => panic()\n    },\n  )\n}\n`);
+        moonbitlang$core$builtin$$Logger$write_string$159$(output, `pub fn ${moonbitlang$core$builtin$$Show$to_string$10$(original_name)}(read_token : () -> (Token, Position, Position), start_pos : Position) -> ${moonbitlang$core$builtin$$Show$to_string$10$(_x$2(name).data_type)}!ParseError {\n  yy_parse!(\n    read_token,\n    start_pos,\n    yy_state_${moonbitlang$core$builtin$$Show$to_string$18$(_x$5.num)},\n    fn {\n      YYObj_${moonbitlang$core$builtin$$Show$to_string$10$(moonbitlang$yacc$lib$codegen$gen_mbt$$esc(_x$2(name).data_type))}(result) => result\n      _ => panic()\n    },\n  )\n}\n`);
       }
       _tmp$8 = _i + 1 | 0;
       continue;
@@ -15716,7 +15765,7 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
   const _bind$2 = moonbitlang$core$sorted_set$$T$iter$10$(used_runtime_funcs);
   _bind$2((func) => {
     if (func === "_get_symbol_start_pos") {
-      moonbitlang$core$builtin$$Logger$write_string$148$(output, "\nfn _get_symbol_start_pos(args : ArrayView[(YYObj, Position, Position)], last_pos : Position) -> Position {\n  if args.length() == 0 {\n    last_pos\n  } else {\n    for i = 0; i < args.length(); i = i + 1 {\n      let (_, start_pos, end_pos) = args[i]\n      if start_pos == end_pos {\n        continue\n      }\n      return start_pos\n    }\n    args[args.length() - 1].2\n  }\n}\n");
+      moonbitlang$core$builtin$$Logger$write_string$159$(output, "\nfn _get_symbol_start_pos(args : ArrayView[(YYObj, Position, Position)], last_pos : Position) -> Position {\n  if args.length() == 0 {\n    last_pos\n  } else {\n    for i = 0; i < args.length(); i = i + 1 {\n      let (_, start_pos, end_pos) = args[i]\n      if start_pos == end_pos {\n        continue\n      }\n      return start_pos\n    }\n    args[args.length() - 1].2\n  }\n}\n");
     } else {
       $panic();
     }
@@ -15724,9 +15773,762 @@ function moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta,
   });
   if (mode.$tag === 0) {
   } else {
-    moonbitlang$core$builtin$$Logger$write_string$148$(output, "\nfn args_to_json(args : ArrayView[(YYObj, Position, Position)]) -> Json {\n  Array(args.iter().map(fn {\n    (YYObj_Json(json), _, _) => json\n    _ => panic()\n  }).to_array())\n}\n");
+    moonbitlang$core$builtin$$Logger$write_string$159$(output, "\nfn args_to_json(args : ArrayView[(YYObj, Position, Position)]) -> Json {\n  Array(args.iter().map(fn {\n    (YYObj_Json(json), _, _) => json\n    _ => panic()\n  }).to_array())\n}\n");
   }
-  moonbitlang$core$builtin$$Logger$write_string$148$(output, meta.footer);
+  moonbitlang$core$builtin$$Logger$write_string$159$(output, meta.footer);
+}
+function moonbitlang$yacc$lib$elab$$map_item_ident(ast_item_ident) {
+  if (ast_item_ident.$tag === 0) {
+    const _Dollar = ast_item_ident;
+    const _x = _Dollar._0;
+    return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemIdent$Dollar(_x);
+  } else {
+    const _Name = ast_item_ident;
+    const _x = _Name._0;
+    return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemIdent$Name(_x);
+  }
+}
+function moonbitlang$yacc$lib$elab$$map_action(ast_action) {
+  const _bind = ast_action.code;
+  let _tmp;
+  if (_bind === undefined) {
+    _tmp = undefined;
+  } else {
+    const _Some = _bind;
+    const _x = _Some;
+    _tmp = { code: _x.code, utf8_pos: _x.utf8_pos, subst: moonbitlang$core$array$$Array$map$142$(_x.subst, (ast_subst) => {
+      const _tmp$2 = ast_subst.start;
+      const _tmp$3 = ast_subst.end;
+      const _bind$2 = ast_subst.desc;
+      let _tmp$4;
+      switch (_bind$2.$tag) {
+        case 0: {
+          const _Dollar = _bind$2;
+          const _x$2 = _Dollar._0;
+          _tmp$4 = new $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$Dollar(_x$2);
+          break;
+        }
+        case 1: {
+          _tmp$4 = $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$StartPos;
+          break;
+        }
+        case 2: {
+          _tmp$4 = $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPos;
+          break;
+        }
+        case 3: {
+          _tmp$4 = $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$Loc;
+          break;
+        }
+        case 4: {
+          const _StartPosOf = _bind$2;
+          const _x$3 = _StartPosOf._0;
+          _tmp$4 = new $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$StartPosOf(moonbitlang$yacc$lib$elab$$map_item_ident(_x$3));
+          break;
+        }
+        case 5: {
+          const _EndPosOf = _bind$2;
+          const _x$4 = _EndPosOf._0;
+          _tmp$4 = new $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPosOf(moonbitlang$yacc$lib$elab$$map_item_ident(_x$4));
+          break;
+        }
+        case 6: {
+          const _LocOf = _bind$2;
+          const _x$5 = _LocOf._0;
+          _tmp$4 = new $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$LocOf(moonbitlang$yacc$lib$elab$$map_item_ident(_x$5));
+          break;
+        }
+        case 7: {
+          _tmp$4 = $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$SymbolStartPos;
+          break;
+        }
+        default: {
+          _tmp$4 = $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$Sloc;
+        }
+      }
+      return { start: _tmp$2, end: _tmp$3, desc: _tmp$4 };
+    }) };
+  }
+  const _tmp$2 = _tmp;
+  const _tmp$3 = ast_action.start;
+  return { code: _tmp$2, start: _tmp$3, end: ast_action.end };
+}
+function moonbitlang$yacc$lib$elab$$map_decl(ast_decl) {
+  switch (ast_decl.$tag) {
+    case 0: {
+      const _Start = ast_decl;
+      const _x = _Start._0;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Start(_x);
+    }
+    case 1: {
+      const _Token = ast_decl;
+      const _x$2 = _Token._0;
+      const _x$3 = _Token._1;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Token(_x$2, _x$3);
+    }
+    case 2: {
+      const _Token1 = ast_decl;
+      const _x$4 = _Token1._0;
+      const _x$5 = _Token1._1;
+      const _x$6 = _Token1._2;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Token1(_x$4, _x$5, _x$6);
+    }
+    case 3: {
+      const _Type = ast_decl;
+      const _x$7 = _Type._0;
+      const _x$8 = _Type._1;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Type(_x$7, _x$8);
+    }
+    case 4: {
+      const _Derive = ast_decl;
+      const _x$9 = _Derive._0;
+      const _x$10 = _Derive._1;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Derive(_x$9, _x$10);
+    }
+    case 5: {
+      const _Position = ast_decl;
+      const _x$11 = _Position._0;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Position(_x$11);
+    }
+    case 6: {
+      const _Left = ast_decl;
+      const _x$12 = _Left._0;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Left(_x$12);
+    }
+    case 7: {
+      const _Right = ast_decl;
+      const _x$13 = _Right._0;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Right(_x$13);
+    }
+    default: {
+      const _Nonassoc = ast_decl;
+      const _x$14 = _Nonassoc._0;
+      return new $64$moonbitlang$47$yacc$47$lib$47$elab$46$Declaration$Nonassoc(_x$14);
+    }
+  }
+}
+function moonbitlang$yacc$lib$elab$$elaborate$46$get_token_by_name$186$(_env, name) {
+  const tokens = _env._1;
+  const token_by_name = _env._0;
+  const _bind = moonbitlang$core$builtin$$Map$get$98$(token_by_name, name);
+  if (_bind === undefined) {
+    const token = { num: moonbitlang$core$builtin$$Map$size$98$(token_by_name), name: name, prec: undefined, type_: undefined, image: undefined };
+    moonbitlang$core$builtin$$Map$op_set$98$(token_by_name, name, token);
+    moonbitlang$core$array$$Array$push$117$(tokens, token);
+    return token;
+  } else {
+    const _Some = _bind;
+    const _x = _Some;
+    return _x;
+  }
+}
+function moonbitlang$yacc$lib$elab$$elaborate(ast_spec) {
+  const header = ast_spec.header;
+  const trailer = ast_spec.trailer;
+  const token_by_name = moonbitlang$core$builtin$$Map$from_array$98$([]);
+  const rule_by_name = moonbitlang$core$builtin$$Map$from_array$99$([]);
+  const token_by_image = moonbitlang$core$builtin$$Map$from_array$98$([]);
+  const tokens = [];
+  const rules = [];
+  const _env = { _0: token_by_name, _1: tokens };
+  const _arr = ast_spec.decls;
+  const _len = _arr.length;
+  let _tmp = 0;
+  while (true) {
+    const _i = _tmp;
+    if (_i < _len) {
+      const ast_decl = _arr[_i];
+      switch (ast_decl.$tag) {
+        case 1: {
+          const _Token = ast_decl;
+          const _x = _Token._0;
+          const _x$2 = _Token._1;
+          const _len$2 = _x.length;
+          let _tmp$2 = 0;
+          while (true) {
+            const _i$2 = _tmp$2;
+            if (_i$2 < _len$2) {
+              const name = _x[_i$2];
+              const token = moonbitlang$yacc$lib$elab$$elaborate$46$get_token_by_name$186$(_env, name);
+              token.type_ = _x$2;
+              _tmp$2 = _i$2 + 1 | 0;
+              continue;
+            } else {
+              break;
+            }
+          }
+          break;
+        }
+        case 2: {
+          const _Token1 = ast_decl;
+          const _x$3 = _Token1._0;
+          const _x$4 = _Token1._1;
+          const _x$5 = _Token1._2;
+          const token = moonbitlang$yacc$lib$elab$$elaborate$46$get_token_by_name$186$(_env, _x$3);
+          token.type_ = _x$4;
+          token.image = _x$5;
+          moonbitlang$core$builtin$$Map$op_set$98$(token_by_image, _x$5, token);
+          break;
+        }
+      }
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  const _arr$2 = ast_spec.rules;
+  const _len$2 = _arr$2.length;
+  let _tmp$2 = 0;
+  while (true) {
+    const _i = _tmp$2;
+    if (_i < _len$2) {
+      const ast_rule = _arr$2[_i];
+      const _bind = moonbitlang$core$builtin$$Map$size$99$(rule_by_name);
+      const _bind$2 = ast_rule.nonterminal;
+      const _bind$3 = ast_rule.type_;
+      const _bind$4 = [];
+      const rule = { num: _bind, name: _bind$2, type_: _bind$3, clauses: _bind$4 };
+      moonbitlang$core$array$$Array$push$118$(rules, rule);
+      moonbitlang$core$builtin$$Map$op_set$99$(rule_by_name, _bind$2, rule);
+      _tmp$2 = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  const curr_prec = { val: 0 };
+  const prec_map = moonbitlang$core$sorted_map$$new$58$();
+  const _arr$3 = ast_spec.decls;
+  const _len$3 = _arr$3.length;
+  let _tmp$3 = 0;
+  while (true) {
+    const _i = _tmp$3;
+    if (_i < _len$3) {
+      const ast_decl = _arr$3[_i];
+      let idents;
+      _L: {
+        _L$2: {
+          switch (ast_decl.$tag) {
+            case 6: {
+              const _Left = ast_decl;
+              const _x = _Left._0;
+              idents = _x;
+              break _L$2;
+            }
+            case 7: {
+              const _Right = ast_decl;
+              const _x$2 = _Right._0;
+              idents = _x$2;
+              break _L$2;
+            }
+            case 8: {
+              const _Nonassoc = ast_decl;
+              const _x$3 = _Nonassoc._0;
+              idents = _x$3;
+              break _L$2;
+            }
+          }
+          break _L;
+        }
+        let assoc;
+        switch (ast_decl.$tag) {
+          case 6: {
+            assoc = 0;
+            break;
+          }
+          case 7: {
+            assoc = 1;
+            break;
+          }
+          case 8: {
+            assoc = 2;
+            break;
+          }
+          default: {
+            assoc = $panic();
+          }
+        }
+        const prec = curr_prec.val;
+        curr_prec.val = curr_prec.val + 1 | 0;
+        const _len$4 = idents.length;
+        let _tmp$4 = 0;
+        while (true) {
+          const _i$2 = _tmp$4;
+          if (_i$2 < _len$4) {
+            const ident = idents[_i$2];
+            moonbitlang$core$sorted_map$$T$op_set$58$(prec_map, ident, { _0: prec, _1: assoc });
+            const _bind = moonbitlang$core$builtin$$Map$op_get$98$(token_by_name, ident);
+            if (_bind === undefined) {
+            } else {
+              const _Some = _bind;
+              const _x = _Some;
+              _x.prec = { _0: prec, _1: assoc };
+            }
+            _tmp$4 = _i$2 + 1 | 0;
+            continue;
+          } else {
+            break;
+          }
+        }
+      }
+      _tmp$3 = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  const decls = moonbitlang$core$array$$Array$map$147$(ast_spec.decls, moonbitlang$yacc$lib$elab$$map_decl);
+  const _arr$4 = ast_spec.rules;
+  const _len$4 = _arr$4.length;
+  let _tmp$4 = 0;
+  while (true) {
+    const _i = _tmp$4;
+    if (_i < _len$4) {
+      const ast_rule = _arr$4[_i];
+      const rule = moonbitlang$core$option$$Option$unwrap$118$(moonbitlang$core$builtin$$Map$op_get$99$(rule_by_name, ast_rule.nonterminal));
+      const _arr$5 = ast_rule.clauses;
+      const _len$5 = _arr$5.length;
+      let _tmp$5 = 0;
+      while (true) {
+        const _i$2 = _tmp$5;
+        if (_i$2 < _len$5) {
+          const ast_clause = _arr$5[_i$2];
+          const items = moonbitlang$core$array$$Array$map$146$(ast_clause.items, (ast_item) => {
+            const _tmp$6 = ast_item.binder;
+            const _bind = ast_item.symbol;
+            let _tmp$7;
+            if (_bind.$tag === 0) {
+              const _Symbol = _bind;
+              const _x = _Symbol._0;
+              const _bind$2 = moonbitlang$core$builtin$$Map$op_get$98$(token_by_name, _x);
+              if (_bind$2 === undefined) {
+                _tmp$7 = new $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemDesc$RuleCall(moonbitlang$core$option$$Option$unwrap$118$(moonbitlang$core$builtin$$Map$op_get$99$(rule_by_name, _x)));
+              } else {
+                const _Some = _bind$2;
+                const _x$2 = _Some;
+                _tmp$7 = new $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemDesc$Token(_x$2);
+              }
+            } else {
+              const _Image = _bind;
+              const _x = _Image._0;
+              _tmp$7 = new $64$moonbitlang$47$yacc$47$lib$47$elab$46$ClauseItemDesc$Token(moonbitlang$core$option$$Option$unwrap$117$(moonbitlang$core$builtin$$Map$op_get$98$(token_by_image, _x)));
+            }
+            return { binder: _tmp$6, desc: _tmp$7 };
+          });
+          const _bind = ast_clause.prec;
+          let prec;
+          if (_bind === undefined) {
+            const last_prec = { val: undefined };
+            const _foreach_result = { val: $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Continue$29$ };
+            const _bind$2 = moonbitlang$core$array$$Array$rev_iter$124$(items);
+            _bind$2((item) => {
+              const _bind$3 = item.desc;
+              if (_bind$3.$tag === 0) {
+                const _Token = _bind$3;
+                const _x = _Token._0;
+                const _bind$4 = _x.prec;
+                let _tmp$6;
+                if (_bind$4 === undefined) {
+                  _tmp$6 = undefined;
+                } else {
+                  const _Some = _bind$4;
+                  const _x$2 = _Some;
+                  const _x$3 = _x$2._0;
+                  _tmp$6 = _x$3;
+                }
+                last_prec.val = _tmp$6;
+                _foreach_result.val = new $64$moonbitlang$47$core$47$builtin$46$ForeachResult$Break$29$(undefined);
+                return 0;
+              }
+              return 1;
+            });
+            const _tmp$6 = _foreach_result.val;
+            switch (_tmp$6.$tag) {
+              case 0: {
+                break;
+              }
+              case 1: {
+                const _break = _tmp$6;
+                _break._0;
+                break;
+              }
+              case 2: {
+                const _return = _tmp$6;
+                return _return._0;
+              }
+              case 3: {
+                $panic();
+                break;
+              }
+              default: {
+                $panic();
+              }
+            }
+            prec = last_prec.val;
+          } else {
+            const _Some = _bind;
+            const _x = _Some;
+            const _bind$2 = moonbitlang$core$option$$Option$unwrap$116$(moonbitlang$core$sorted_map$$T$op_get$58$(prec_map, _x));
+            const _x$2 = _bind$2._0;
+            prec = _x$2;
+          }
+          const clause = { items: items, prec: prec, action: moonbitlang$yacc$lib$elab$$map_action(ast_clause.action) };
+          moonbitlang$core$array$$Array$push$132$(rule.clauses, clause);
+          _tmp$5 = _i$2 + 1 | 0;
+          continue;
+        } else {
+          break;
+        }
+      }
+      _tmp$4 = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  return { header: header, trailer: trailer, decls: decls, tokens: tokens, rules: rules };
+}
+function moonbitlang$core$builtin$$Eq$op_equal$22$(_x_167, _x_168) {
+  switch (_x_167.$tag) {
+    case 0: {
+      const _Dollar = _x_167;
+      const _x = _Dollar._0;
+      if (_x_168.$tag === 0) {
+        const _Dollar$2 = _x_168;
+        const _x$2 = _Dollar$2._0;
+        return _x === _x$2;
+      } else {
+        return false;
+      }
+    }
+    case 1: {
+      if (_x_168.$tag === 1) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    case 2: {
+      if (_x_168.$tag === 2) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    case 3: {
+      if (_x_168.$tag === 3) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    case 4: {
+      const _StartPosOf = _x_167;
+      const _x$2 = _StartPosOf._0;
+      if (_x_168.$tag === 4) {
+        const _StartPosOf$2 = _x_168;
+        const _x$3 = _StartPosOf$2._0;
+        return moonbitlang$core$builtin$$Eq$op_equal$187$(_x$2, _x$3);
+      } else {
+        return false;
+      }
+    }
+    case 5: {
+      const _EndPosOf = _x_167;
+      const _x$3 = _EndPosOf._0;
+      if (_x_168.$tag === 5) {
+        const _EndPosOf$2 = _x_168;
+        const _x$4 = _EndPosOf$2._0;
+        return moonbitlang$core$builtin$$Eq$op_equal$187$(_x$3, _x$4);
+      } else {
+        return false;
+      }
+    }
+    case 6: {
+      const _LocOf = _x_167;
+      const _x$4 = _LocOf._0;
+      if (_x_168.$tag === 6) {
+        const _LocOf$2 = _x_168;
+        const _x$5 = _LocOf$2._0;
+        return moonbitlang$core$builtin$$Eq$op_equal$187$(_x$4, _x$5);
+      } else {
+        return false;
+      }
+    }
+    case 7: {
+      if (_x_168.$tag === 7) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    default: {
+      if (_x_168.$tag === 8) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+}
+function moonbitlang$core$builtin$$Compare$compare$22$(_x_147, _x_148) {
+  switch (_x_147.$tag) {
+    case 0: {
+      const _Dollar = _x_147;
+      const _x = _Dollar._0;
+      if (_x_148.$tag === 0) {
+        const _Dollar$2 = _x_148;
+        const _x$2 = _Dollar$2._0;
+        return $compare_int(_x, _x$2);
+      } else {
+        return -1;
+      }
+    }
+    case 1: {
+      switch (_x_148.$tag) {
+        case 0: {
+          return 1;
+        }
+        case 1: {
+          return 0;
+        }
+        default: {
+          return -1;
+        }
+      }
+    }
+    case 2: {
+      switch (_x_148.$tag) {
+        case 0: {
+          return 1;
+        }
+        case 1: {
+          return 1;
+        }
+        case 2: {
+          return 0;
+        }
+        default: {
+          return -1;
+        }
+      }
+    }
+    case 3: {
+      switch (_x_148.$tag) {
+        case 0: {
+          return 1;
+        }
+        case 1: {
+          return 1;
+        }
+        case 2: {
+          return 1;
+        }
+        case 3: {
+          return 0;
+        }
+        default: {
+          return -1;
+        }
+      }
+    }
+    case 4: {
+      const _StartPosOf = _x_147;
+      const _x$2 = _StartPosOf._0;
+      switch (_x_148.$tag) {
+        case 0: {
+          return 1;
+        }
+        case 1: {
+          return 1;
+        }
+        case 2: {
+          return 1;
+        }
+        case 3: {
+          return 1;
+        }
+        case 4: {
+          const _StartPosOf$2 = _x_148;
+          const _x$3 = _StartPosOf$2._0;
+          return moonbitlang$core$builtin$$Compare$compare$187$(_x$2, _x$3);
+        }
+        default: {
+          return -1;
+        }
+      }
+    }
+    case 5: {
+      const _EndPosOf = _x_147;
+      const _x$4 = _EndPosOf._0;
+      switch (_x_148.$tag) {
+        case 0: {
+          return 1;
+        }
+        case 1: {
+          return 1;
+        }
+        case 2: {
+          return 1;
+        }
+        case 3: {
+          return 1;
+        }
+        case 4: {
+          return 1;
+        }
+        case 5: {
+          const _EndPosOf$2 = _x_148;
+          const _x$5 = _EndPosOf$2._0;
+          return moonbitlang$core$builtin$$Compare$compare$187$(_x$4, _x$5);
+        }
+        default: {
+          return -1;
+        }
+      }
+    }
+    case 6: {
+      const _LocOf = _x_147;
+      const _x$6 = _LocOf._0;
+      switch (_x_148.$tag) {
+        case 0: {
+          return 1;
+        }
+        case 1: {
+          return 1;
+        }
+        case 2: {
+          return 1;
+        }
+        case 3: {
+          return 1;
+        }
+        case 4: {
+          return 1;
+        }
+        case 5: {
+          return 1;
+        }
+        case 6: {
+          const _LocOf$2 = _x_148;
+          const _x$7 = _LocOf$2._0;
+          return moonbitlang$core$builtin$$Compare$compare$187$(_x$6, _x$7);
+        }
+        default: {
+          return -1;
+        }
+      }
+    }
+    case 7: {
+      switch (_x_148.$tag) {
+        case 0: {
+          return 1;
+        }
+        case 1: {
+          return 1;
+        }
+        case 2: {
+          return 1;
+        }
+        case 3: {
+          return 1;
+        }
+        case 4: {
+          return 1;
+        }
+        case 5: {
+          return 1;
+        }
+        case 6: {
+          return 1;
+        }
+        case 7: {
+          return 0;
+        }
+        default: {
+          return -1;
+        }
+      }
+    }
+    default: {
+      switch (_x_148.$tag) {
+        case 0: {
+          return 1;
+        }
+        case 1: {
+          return 1;
+        }
+        case 2: {
+          return 1;
+        }
+        case 3: {
+          return 1;
+        }
+        case 4: {
+          return 1;
+        }
+        case 5: {
+          return 1;
+        }
+        case 6: {
+          return 1;
+        }
+        case 7: {
+          return 1;
+        }
+        default: {
+          return 0;
+        }
+      }
+    }
+  }
+}
+function moonbitlang$core$builtin$$Eq$op_equal$187$(_x_104, _x_105) {
+  if (_x_104.$tag === 0) {
+    const _Dollar = _x_104;
+    const _x = _Dollar._0;
+    if (_x_105.$tag === 0) {
+      const _Dollar$2 = _x_105;
+      const _x$2 = _Dollar$2._0;
+      return _x === _x$2;
+    } else {
+      return false;
+    }
+  } else {
+    const _Name = _x_104;
+    const _x = _Name._0;
+    if (_x_105.$tag === 1) {
+      const _Name$2 = _x_105;
+      const _x$2 = _Name$2._0;
+      return _x === _x$2;
+    } else {
+      return false;
+    }
+  }
+}
+function moonbitlang$core$builtin$$Compare$compare$187$(_x_92, _x_93) {
+  if (_x_92.$tag === 0) {
+    const _Dollar = _x_92;
+    const _x = _Dollar._0;
+    if (_x_93.$tag === 0) {
+      const _Dollar$2 = _x_93;
+      const _x$2 = _Dollar$2._0;
+      return $compare_int(_x, _x$2);
+    } else {
+      return -1;
+    }
+  } else {
+    const _Name = _x_92;
+    const _x = _Name._0;
+    if (_x_93.$tag === 0) {
+      return 1;
+    } else {
+      const _Name$2 = _x_93;
+      const _x$2 = _Name$2._0;
+      return moonbitlang$core$string$$String$compare(_x, _x$2);
+    }
+  }
 }
 function moonbitlang$yacc$lib$driver$$offset_to_line_column(content, offset) {
   let line = 1;
@@ -15765,7 +16567,7 @@ function moonbitlang$yacc$lib$driver$$array_to_or_list(arr) {
       const self = [];
       moonbitlang$core$array$$Array$push_iter$10$(self, moonbitlang$core$array$$ArrayView$iter$10$(_x$2));
       const left = moonbitlang$core$string$$String$concat(self, ", ");
-      return `${left} or ${_x}`;
+      return `${moonbitlang$core$builtin$$Show$to_string$10$(left)} or ${moonbitlang$core$builtin$$Show$to_string$10$(_x)}`;
     }
   }
 }
@@ -15776,53 +16578,15 @@ function moonbitlang$yacc$lib$driver$$loc_to_string(filename, content, loc) {
   const _bind$2 = moonbitlang$yacc$lib$driver$$offset_to_line_column(content, loc._1);
   const _x$3 = _bind$2._0;
   const _x$4 = _bind$2._1;
-  return _x === _x$3 ? `${filename}:${moonbitlang$core$int$$Int$to_string(_x)}:${moonbitlang$core$int$$Int$to_string(_x$2)}-${moonbitlang$core$int$$Int$to_string(_x$4)}` : `${filename}:${moonbitlang$core$int$$Int$to_string(_x)}:${moonbitlang$core$int$$Int$to_string(_x$2)}-${moonbitlang$core$int$$Int$to_string(_x$3)}:${moonbitlang$core$int$$Int$to_string(_x$4)}`;
+  return _x === _x$3 ? `${moonbitlang$core$builtin$$Show$to_string$10$(filename)}:${moonbitlang$core$builtin$$Show$to_string$18$(_x)}:${moonbitlang$core$builtin$$Show$to_string$18$(_x$2)}-${moonbitlang$core$builtin$$Show$to_string$18$(_x$4)}` : `${moonbitlang$core$builtin$$Show$to_string$10$(filename)}:${moonbitlang$core$builtin$$Show$to_string$18$(_x)}:${moonbitlang$core$builtin$$Show$to_string$18$(_x$2)}-${moonbitlang$core$builtin$$Show$to_string$18$(_x$3)}:${moonbitlang$core$builtin$$Show$to_string$18$(_x$4)}`;
 }
-function moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$175$(_env, name) {
-  const terminals = _env._1;
-  const terminal_by_name = _env._0;
-  const _bind = moonbitlang$core$builtin$$Map$get$97$(terminal_by_name, name);
-  if (_bind === undefined) {
-    const num = terminals.length;
-    const term = { num: num, name: name, references: [], prec: undefined };
-    moonbitlang$core$array$$Array$push$89$(terminals, term);
-    moonbitlang$core$builtin$$Map$op_set$97$(terminal_by_name, name, term);
-    return term;
-  } else {
-    const _Some = _bind;
-    const _x = _Some;
-    return _x;
-  }
+function moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$188$(terminal_by_name, name) {
+  return moonbitlang$core$option$$Option$unwrap$89$(moonbitlang$core$builtin$$Map$get$100$(terminal_by_name, name));
 }
-function moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$176$(_env, name) {
-  const nonterminals = _env._1;
-  const nonterminal_by_name = _env._0;
-  const _bind = moonbitlang$core$builtin$$Map$get$98$(nonterminal_by_name, name);
-  if (_bind === undefined) {
-    const num = nonterminals.length;
-    const nonterm = { num: num, name: name, productions: [], references: [], nullability: 2 };
-    moonbitlang$core$array$$Array$push$18$(nonterminals, nonterm);
-    moonbitlang$core$builtin$$Map$op_set$98$(nonterminal_by_name, name, nonterm);
-    return nonterm;
-  } else {
-    const _Some = _bind;
-    const _x = _Some;
-    return _x;
-  }
+function moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$189$(nonterminal_by_name, name) {
+  return moonbitlang$core$option$$Option$unwrap$96$(moonbitlang$core$builtin$$Map$get$101$(nonterminal_by_name, name));
 }
-function moonbitlang$yacc$lib$driver$$compile$46$get_symbol_by_name$177$(_env, name) {
-  const terminal_by_name = _env._1;
-  const nonterminal_by_name = _env._0;
-  const _bind = moonbitlang$core$builtin$$Map$get$97$(terminal_by_name, name);
-  if (_bind === undefined) {
-    return new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$NT(moonbitlang$core$option$$Option$unwrap$18$(moonbitlang$core$builtin$$Map$op_get$98$(nonterminal_by_name, name)));
-  } else {
-    const _Some = _bind;
-    const _x = _Some;
-    return new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$T(_x);
-  }
-}
-function moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$178$(ident) {
+function moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$190$(ident) {
   if (ident.$tag === 0) {
     const _Dollar = ident;
     const _x = _Dollar._0;
@@ -15831,74 +16595,74 @@ function moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$178$(ident)
     return $panic();
   }
 }
-function moonbitlang$yacc$lib$driver$$compile$46$add_binding$179$(_env, desc) {
+function moonbitlang$yacc$lib$driver$$compile$46$add_binding$191$(_env, desc) {
   const bindings = _env._2;
   const visited = _env._1;
   const production = _env._0;
   let _tmp = desc;
   _L: while (true) {
     const desc$2 = _tmp;
-    if (!moonbitlang$core$sorted_set$$T$contains$19$(visited, desc$2)) {
-      moonbitlang$core$sorted_set$$T$add$19$(visited, desc$2);
+    if (!moonbitlang$core$sorted_set$$T$contains$22$(visited, desc$2)) {
+      moonbitlang$core$sorted_set$$T$add$22$(visited, desc$2);
       switch (desc$2.$tag) {
         case 0: {
           const _Dollar = desc$2;
           const _x = _Dollar._0;
-          const name = `_dollar${moonbitlang$core$int$$Int$to_string(_x)}`;
-          moonbitlang$core$array$$Array$push$129$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$Data(_x - 1 | 0), _1: name });
+          const name = `_dollar${moonbitlang$core$builtin$$Show$to_string$18$(_x)}`;
+          moonbitlang$core$array$$Array$push$137$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$Data(_x - 1 | 0), _1: name });
           return;
         }
         case 1: {
           if (production.rhs.length === 0) {
-            moonbitlang$core$array$$Array$push$129$(bindings, { _0: $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$LastPos, _1: "_start_pos" });
+            moonbitlang$core$array$$Array$push$137$(bindings, { _0: $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$LastPos, _1: "_start_pos" });
             return;
           } else {
-            moonbitlang$core$array$$Array$push$129$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$StartPos(0), _1: "_start_pos" });
+            moonbitlang$core$array$$Array$push$137$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$StartPos(0), _1: "_start_pos" });
             return;
           }
         }
         case 3: {
-          moonbitlang$yacc$lib$driver$$compile$46$add_binding$179$(_env, $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$StartPos);
-          _tmp = $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$EndPos;
+          moonbitlang$yacc$lib$driver$$compile$46$add_binding$191$(_env, $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$StartPos);
+          _tmp = $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPos;
           continue _L;
         }
         case 2: {
           if (production.rhs.length === 0) {
-            moonbitlang$core$array$$Array$push$129$(bindings, { _0: $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$LastPos, _1: "_end_pos" });
+            moonbitlang$core$array$$Array$push$137$(bindings, { _0: $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$LastPos, _1: "_end_pos" });
             return;
           } else {
-            moonbitlang$core$array$$Array$push$129$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$EndPos(production.rhs.length - 1 | 0), _1: "_end_pos" });
+            moonbitlang$core$array$$Array$push$137$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$EndPos(production.rhs.length - 1 | 0), _1: "_end_pos" });
             return;
           }
         }
         case 4: {
           const _StartPosOf = desc$2;
           const _x$2 = _StartPosOf._0;
-          const index = moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$178$(_x$2);
-          moonbitlang$core$array$$Array$push$129$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$StartPos(index), _1: `_start_pos_of_item${moonbitlang$core$int$$Int$to_string(index)}` });
+          const index = moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$190$(_x$2);
+          moonbitlang$core$array$$Array$push$137$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$StartPos(index), _1: `_start_pos_of_item${moonbitlang$core$builtin$$Show$to_string$18$(index)}` });
           return;
         }
         case 5: {
           const _EndPosOf = desc$2;
           const _x$3 = _EndPosOf._0;
-          const index$2 = moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$178$(_x$3);
-          moonbitlang$core$array$$Array$push$129$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$EndPos(index$2), _1: `_end_pos_of_item${moonbitlang$core$int$$Int$to_string(index$2)}` });
+          const index$2 = moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$190$(_x$3);
+          moonbitlang$core$array$$Array$push$137$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$EndPos(index$2), _1: `_end_pos_of_item${moonbitlang$core$builtin$$Show$to_string$18$(index$2)}` });
           return;
         }
         case 6: {
           const _LocOf = desc$2;
           const _x$4 = _LocOf._0;
-          moonbitlang$yacc$lib$driver$$compile$46$add_binding$179$(_env, new $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$StartPosOf(_x$4));
-          _tmp = new $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$EndPosOf(_x$4);
+          moonbitlang$yacc$lib$driver$$compile$46$add_binding$191$(_env, new $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$StartPosOf(_x$4));
+          _tmp = new $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPosOf(_x$4);
           continue _L;
         }
         case 7: {
-          moonbitlang$core$array$$Array$push$129$(bindings, { _0: $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$SymbolStartPos, _1: "_symbol_start_pos" });
+          moonbitlang$core$array$$Array$push$137$(bindings, { _0: $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$SymbolStartPos, _1: "_symbol_start_pos" });
           return;
         }
         default: {
-          moonbitlang$yacc$lib$driver$$compile$46$add_binding$179$(_env, $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$SymbolStartPos);
-          _tmp = $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$EndPos;
+          moonbitlang$yacc$lib$driver$$compile$46$add_binding$191$(_env, $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$SymbolStartPos);
+          _tmp = $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPos;
           continue _L;
         }
       }
@@ -15907,29 +16671,9 @@ function moonbitlang$yacc$lib$driver$$compile$46$add_binding$179$(_env, desc) {
     }
   }
 }
-function moonbitlang$yacc$lib$driver$$compile$46$is_nullable$180$(symbol) {
-  if (symbol.$tag === 0) {
-    return false;
-  } else {
-    const _NT = symbol;
-    const _x = _NT._0;
-    const _x$2 = _x.nullability;
-    switch (_x$2) {
-      case 0: {
-        return true;
-      }
-      case 1: {
-        return true;
-      }
-      default: {
-        return false;
-      }
-    }
-  }
-}
 function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode, filename, external_tokens, no_comments, source_map_builder) {
   const lexer = moonbitlang$yacc$lib$parser$$new_lexer(parser_spec_str);
-  const token = () => moonbitlang$core$result$$Result$unwrap$16$(moonbitlang$yacc$lib$parser$$Lexer$next_token(lexer));
+  const token = () => moonbitlang$core$result$$Result$unwrap$19$(moonbitlang$yacc$lib$parser$$Lexer$next_token(lexer));
   let spec;
   let _try_err;
   _L: {
@@ -15951,42 +16695,132 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
     const _x$2 = _UnexpectedToken._1;
     const _x$3 = _UnexpectedToken._2;
     const loc_str = moonbitlang$yacc$lib$driver$$loc_to_string(filename, parser_spec_str, _x$2);
-    const _bind = moonbitlang$core$array$$Array$map$141$(_x$3, moonbitlang$core$builtin$$Show$to_string$151$);
+    const _bind = moonbitlang$core$array$$Array$map$152$(_x$3, moonbitlang$core$builtin$$Show$to_string$163$);
     const expected_str = moonbitlang$yacc$lib$driver$$array_to_or_list({ buf: _bind, start: 0, len: _bind.length });
-    moonbitlang$yacc$lib$driver$util$$println_to_stderr(`SyntaxError: Unexpected token ${moonbitlang$core$builtin$$Show$to_string$151$(moonbitlang$yacc$lib$parser$$Token$kind(_x))}, expected ${expected_str}.\n  at ${loc_str}`);
-    spec = moonbitlang$yacc$lib$driver$util$$exit$162$(1);
+    moonbitlang$yacc$lib$driver$util$$println_to_stderr(`SyntaxError: Unexpected token ${moonbitlang$core$builtin$$Show$to_string$163$(moonbitlang$yacc$lib$parser$$Token$kind(_x))}, expected ${moonbitlang$core$builtin$$Show$to_string$10$(expected_str)}.\n  at ${moonbitlang$core$builtin$$Show$to_string$10$(loc_str)}`);
+    spec = moonbitlang$yacc$lib$driver$util$$exit$173$(1);
   }
+  const spec$2 = moonbitlang$yacc$lib$elab$$elaborate(spec);
   const terminals = [];
   const nonterminals = [];
-  const terminal_by_name = moonbitlang$core$builtin$$Map$from_array$97$([]);
-  const terminal_by_image = moonbitlang$core$builtin$$Map$from_array$97$([]);
-  const nonterminal_by_name = moonbitlang$core$builtin$$Map$from_array$98$([]);
-  const production_meta_map = moonbitlang$core$builtin$$Map$from_array$99$([]);
-  const terminal_meta_map = moonbitlang$core$builtin$$Map$from_array$100$([]);
-  const nonterminal_meta_map = moonbitlang$core$builtin$$Map$from_array$101$([]);
-  const _env = { _0: terminal_by_name, _1: terminals };
-  const _env$2 = { _0: nonterminal_by_name, _1: nonterminals };
-  const _arr = spec.decls;
+  const terminal_by_name = moonbitlang$core$builtin$$Map$from_array$100$([]);
+  const nonterminal_by_name = moonbitlang$core$builtin$$Map$from_array$101$([]);
+  const _arr = spec$2.tokens;
   const _len = _arr.length;
   let _tmp = 0;
   while (true) {
     const _i = _tmp;
     if (_i < _len) {
-      const cmd = _arr[_i];
-      switch (cmd.$tag) {
+      const token$2 = _arr[_i];
+      const _tmp$2 = token$2.num;
+      const _tmp$3 = token$2.name;
+      const _bind = token$2.prec;
+      let _tmp$4;
+      if (_bind === undefined) {
+        _tmp$4 = undefined;
+      } else {
+        const _Some = _bind;
+        const _x = _Some;
+        const _x$2 = _x._0;
+        const _x$3 = _x._1;
+        switch (_x$3) {
+          case 2: {
+            _tmp$4 = { _0: _x$2, _1: 2 };
+            break;
+          }
+          case 0: {
+            _tmp$4 = { _0: _x$2, _1: 0 };
+            break;
+          }
+          default: {
+            _tmp$4 = { _0: _x$2, _1: 1 };
+          }
+        }
+      }
+      const terminal = { num: _tmp$2, name: _tmp$3, prec: _tmp$4 };
+      moonbitlang$core$builtin$$Map$op_set$100$(terminal_by_name, token$2.name, terminal);
+      moonbitlang$core$array$$Array$push$89$(terminals, terminal);
+      _tmp = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  const _arr$2 = spec$2.rules;
+  const _len$2 = _arr$2.length;
+  let _tmp$2 = 0;
+  while (true) {
+    const _i = _tmp$2;
+    if (_i < _len$2) {
+      const rule = _arr$2[_i];
+      const nonterminal = { num: rule.num, name: rule.name, productions: [] };
+      moonbitlang$core$builtin$$Map$op_set$101$(nonterminal_by_name, rule.name, nonterminal);
+      moonbitlang$core$array$$Array$push$96$(nonterminals, nonterminal);
+      _tmp$2 = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  const production_meta_map = moonbitlang$core$builtin$$Map$from_array$102$([]);
+  const terminal_meta_map = moonbitlang$core$builtin$$Map$from_array$103$([]);
+  const nonterminal_meta_map = moonbitlang$core$builtin$$Map$from_array$104$([]);
+  if (mode.$tag === 2) {
+    const output = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
+    moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, (name) => moonbitlang$core$builtin$$Map$get_or_init$103$(terminal_meta_map, moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$188$(terminal_by_name, name).num, () => ({ data_type: undefined, image: undefined })), { self: output, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char }, no_comments, moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$derive_map$46$default());
+    return moonbitlang$core$builtin$$StringBuilder$to_string(output);
+  }
+  const productions = [];
+  const starts = [];
+  let position_data_type = "Unit";
+  let derive_map = moonbitlang$core$immut$hashmap$$new$50$();
+  const _arr$3 = spec$2.decls;
+  const _len$3 = _arr$3.length;
+  let _tmp$3 = 0;
+  while (true) {
+    const _i = _tmp$3;
+    if (_i < _len$3) {
+      const decl = _arr$3[_i];
+      switch (decl.$tag) {
         case 1: {
-          const _Token = cmd;
-          const _x = _Token._0;
-          const _x$2 = _Token._1;
-          const _len$2 = _x.length;
-          let _tmp$2 = 0;
+          break;
+        }
+        case 2: {
+          break;
+        }
+        case 0: {
+          const _Start = decl;
+          const _x = _Start._0;
+          moonbitlang$core$array$$Array$push_iter$10$(starts, moonbitlang$core$array$$Array$iter$10$(_x));
+          break;
+        }
+        case 3: {
+          const _Type = decl;
+          const _x$2 = _Type._0;
+          const _x$3 = _Type._1;
+          const _len$4 = _x$2.length;
+          let _tmp$4 = 0;
           while (true) {
-            const _i$2 = _tmp$2;
-            if (_i$2 < _len$2) {
-              const name = _x[_i$2];
-              const t = moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$175$(_env, name);
-              moonbitlang$core$builtin$$Map$op_set$100$(terminal_meta_map, t.num, { data_type: _x$2, image: undefined });
-              _tmp$2 = _i$2 + 1 | 0;
+            const _i$2 = _tmp$4;
+            if (_i$2 < _len$4) {
+              const name = _x$2[_i$2];
+              const _bind = moonbitlang$core$builtin$$Map$get$100$(terminal_by_name, name);
+              let symbol;
+              if (_bind === undefined) {
+                symbol = new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$NT(moonbitlang$core$option$$Option$unwrap$96$(moonbitlang$core$builtin$$Map$op_get$101$(nonterminal_by_name, name)));
+              } else {
+                const _Some = _bind;
+                const _x$4 = _Some;
+                symbol = new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$T(_x$4);
+              }
+              if (symbol.$tag === 0) {
+                $panic();
+              } else {
+                const _NT = symbol;
+                const _x$4 = _NT._0;
+                moonbitlang$core$builtin$$Map$op_set$104$(nonterminal_meta_map, _x$4.num, { data_type: _x$3 });
+              }
+              _tmp$4 = _i$2 + 1 | 0;
               continue;
             } else {
               break;
@@ -15994,181 +16828,44 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
           }
           break;
         }
-        case 2: {
-          const _Token1 = cmd;
-          const _x$3 = _Token1._0;
-          const _x$4 = _Token1._1;
-          const _x$5 = _Token1._2;
-          const t = moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$175$(_env, _x$3);
-          moonbitlang$core$builtin$$Map$op_set$100$(terminal_meta_map, t.num, { data_type: _x$4, image: _x$5 });
-          moonbitlang$core$builtin$$Map$op_set$97$(terminal_by_image, _x$5, t);
+        case 5: {
+          const _Position = decl;
+          const _x$4 = _Position._0;
+          position_data_type = _x$4;
           break;
         }
-      }
-      _tmp = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  if (mode.$tag === 2) {
-    const output = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
-    moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens(terminals, (name) => moonbitlang$core$builtin$$Map$get_or_init$100$(terminal_meta_map, moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$175$(_env, name).num, () => ({ data_type: undefined, image: undefined })), { self: output, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char }, no_comments, moonbitlang$yacc$lib$codegen$gen_mbt$$codegen_tokens$46$derive_map$46$default());
-    return moonbitlang$core$builtin$$StringBuilder$to_string(output);
-  }
-  const _arr$2 = spec.rules;
-  const _len$2 = _arr$2.length;
-  let _tmp$2 = 0;
-  while (true) {
-    const _i = _tmp$2;
-    if (_i < _len$2) {
-      const rule = _arr$2[_i];
-      moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$176$(_env$2, rule.nonterminal);
-      _tmp$2 = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  const _env$3 = { _0: nonterminal_by_name, _1: terminal_by_name };
-  const productions = [];
-  const starts = [];
-  const curr_prec = { val: 0 };
-  let position_data_type = "Unit";
-  let derive_map = moonbitlang$core$immut$hashmap$$new$49$();
-  const prec_map = moonbitlang$core$sorted_map$$new$58$();
-  const _arr$3 = spec.decls;
-  const _len$3 = _arr$3.length;
-  let _tmp$3 = 0;
-  while (true) {
-    const _i = _tmp$3;
-    if (_i < _len$3) {
-      const cmd = _arr$3[_i];
-      let names;
-      _L$2: {
-        _L$3: {
-          switch (cmd.$tag) {
-            case 1: {
+        case 6: {
+          break;
+        }
+        case 7: {
+          break;
+        }
+        case 8: {
+          break;
+        }
+        default: {
+          const _Derive = decl;
+          const _x$5 = _Derive._0;
+          const _x$6 = _Derive._1;
+          let type_;
+          switch (_x$6) {
+            case "Token": {
+              type_ = 0;
               break;
             }
-            case 2: {
+            case "TokenKind": {
+              type_ = 1;
               break;
             }
-            case 0: {
-              const _Start = cmd;
-              const _x = _Start._0;
-              moonbitlang$core$array$$Array$push_iter$10$(starts, moonbitlang$core$array$$Array$iter$10$(_x));
+            case "ParseError": {
+              type_ = 2;
               break;
-            }
-            case 3: {
-              const _Type = cmd;
-              const _x$2 = _Type._0;
-              const _x$3 = _Type._1;
-              const _len$4 = _x$2.length;
-              let _tmp$4 = 0;
-              while (true) {
-                const _i$2 = _tmp$4;
-                if (_i$2 < _len$4) {
-                  const name = _x$2[_i$2];
-                  const symbol = moonbitlang$yacc$lib$driver$$compile$46$get_symbol_by_name$177$(_env$3, name);
-                  if (symbol.$tag === 0) {
-                    $panic();
-                  } else {
-                    const _NT = symbol;
-                    const _x$4 = _NT._0;
-                    moonbitlang$core$builtin$$Map$op_set$101$(nonterminal_meta_map, _x$4.num, { data_type: _x$3 });
-                  }
-                  _tmp$4 = _i$2 + 1 | 0;
-                  continue;
-                } else {
-                  break;
-                }
-              }
-              break;
-            }
-            case 5: {
-              const _Position = cmd;
-              const _x$4 = _Position._0;
-              position_data_type = _x$4;
-              break;
-            }
-            case 6: {
-              const _Left = cmd;
-              const _x$5 = _Left._0;
-              names = _x$5;
-              break _L$3;
-            }
-            case 7: {
-              const _Right = cmd;
-              const _x$6 = _Right._0;
-              names = _x$6;
-              break _L$3;
-            }
-            case 8: {
-              const _Nonassoc = cmd;
-              const _x$7 = _Nonassoc._0;
-              names = _x$7;
-              break _L$3;
             }
             default: {
-              const _Derive = cmd;
-              const _x$8 = _Derive._0;
-              const _x$9 = _Derive._1;
-              let type_;
-              switch (_x$9) {
-                case "Token": {
-                  type_ = 0;
-                  break;
-                }
-                case "TokenKind": {
-                  type_ = 1;
-                  break;
-                }
-                case "ParseError": {
-                  type_ = 2;
-                  break;
-                }
-                default: {
-                  type_ = $panic();
-                }
-              }
-              derive_map = moonbitlang$core$immut$hashmap$$T$add$49$(derive_map, type_, _x$8);
+              type_ = $panic();
             }
           }
-          break _L$2;
-        }
-        let assoc;
-        switch (cmd.$tag) {
-          case 6: {
-            assoc = 0;
-            break;
-          }
-          case 7: {
-            assoc = 1;
-            break;
-          }
-          case 8: {
-            assoc = 2;
-            break;
-          }
-          default: {
-            assoc = $panic();
-          }
-        }
-        const prec = curr_prec.val;
-        curr_prec.val = curr_prec.val + 1 | 0;
-        const _len$4 = names.length;
-        let _tmp$4 = 0;
-        while (true) {
-          const _i$2 = _tmp$4;
-          if (_i$2 < _len$4) {
-            const name = names[_i$2];
-            moonbitlang$core$sorted_map$$T$op_set$58$(prec_map, name, { _0: prec, _1: assoc });
-            _tmp$4 = _i$2 + 1 | 0;
-            continue;
-          } else {
-            break;
-          }
+          derive_map = moonbitlang$core$immut$hashmap$$T$add$50$(derive_map, type_, _x$5);
         }
       }
       _tmp$3 = _i + 1 | 0;
@@ -16191,110 +16888,74 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
       position_data_type = "Int";
       if (_x === undefined) {
       } else {
-        const x = moonbitlang$core$option$$Option$or$10$(moonbitlang$core$immut$hashmap$$T$op_get$49$(derive_map, 0), "");
+        const x = moonbitlang$core$option$$Option$or$10$(moonbitlang$core$immut$hashmap$$T$op_get$50$(derive_map, 0), "");
         const _bind = moonbitlang$core$string$$String$split(x, ",");
         if (!moonbitlang$core$builtin$$Iter$contains$10$((_p) => _bind((_p$2) => _p(moonbitlang$core$string$$String$trim(_p$2, " "))), moonbitlang$yacc$lib$driver$$compile$46$y$4$)) {
           const z = x === "" ? moonbitlang$yacc$lib$driver$$compile$46$y$4$ : `${x}, ${moonbitlang$yacc$lib$driver$$compile$46$y$4$}`;
-          derive_map = moonbitlang$core$immut$hashmap$$T$add$49$(derive_map, 0, z);
+          derive_map = moonbitlang$core$immut$hashmap$$T$add$50$(derive_map, 0, z);
         }
       }
     }
   }
-  const _bind = moonbitlang$core$sorted_map$$T$iter2$58$(prec_map);
-  _bind((name, prec) => {
-    const _bind$2 = moonbitlang$core$builtin$$Map$get$97$(terminal_by_name, name);
-    if (_bind$2 === undefined) {
-    } else {
-      const _Some = _bind$2;
-      const _x$2 = _Some;
-      _x$2.prec = prec;
-    }
-    return 1;
-  });
-  const _arr$4 = spec.rules;
+  const _arr$4 = spec$2.tokens;
   const _len$4 = _arr$4.length;
   let _tmp$4 = 0;
   while (true) {
     const _i = _tmp$4;
     if (_i < _len$4) {
-      const rule = _arr$4[_i];
-      const lhs = moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$176$(_env$2, rule.nonterminal);
-      const _bind$2 = rule.type_;
-      if (_bind$2 === undefined) {
-        const _bind$3 = moonbitlang$core$builtin$$Map$op_get$101$(nonterminal_meta_map, lhs.num);
-        if (_bind$3 === undefined) {
-          moonbitlang$core$builtin$$Map$op_set$101$(nonterminal_meta_map, lhs.num, { data_type: "Unit" });
+      const token$2 = _arr$4[_i];
+      const terminal = moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$188$(terminal_by_name, token$2.name);
+      moonbitlang$core$builtin$$Map$op_set$103$(terminal_meta_map, terminal.num, { data_type: token$2.type_, image: token$2.image });
+      _tmp$4 = _i + 1 | 0;
+      continue;
+    } else {
+      break;
+    }
+  }
+  const _arr$5 = spec$2.rules;
+  const _len$5 = _arr$5.length;
+  let _tmp$5 = 0;
+  while (true) {
+    const _i = _tmp$5;
+    if (_i < _len$5) {
+      const rule = _arr$5[_i];
+      const lhs = moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$189$(nonterminal_by_name, rule.name);
+      const _bind = rule.type_;
+      if (_bind === undefined) {
+        const _bind$2 = moonbitlang$core$builtin$$Map$op_get$104$(nonterminal_meta_map, lhs.num);
+        if (_bind$2 === undefined) {
+          moonbitlang$core$builtin$$Map$op_set$104$(nonterminal_meta_map, lhs.num, { data_type: "Unit" });
         }
       } else {
-        const _Some = _bind$2;
+        const _Some = _bind;
         const _x$2 = _Some;
-        moonbitlang$core$builtin$$Map$op_set$101$(nonterminal_meta_map, lhs.num, { data_type: _x$2 });
+        moonbitlang$core$builtin$$Map$op_set$104$(nonterminal_meta_map, lhs.num, { data_type: _x$2 });
       }
-      const _arr$5 = rule.clauses;
-      const _len$5 = _arr$5.length;
-      let _tmp$5 = 0;
+      const _arr$6 = rule.clauses;
+      const _len$6 = _arr$6.length;
+      let _tmp$6 = 0;
       while (true) {
-        const _i$2 = _tmp$5;
-        if (_i$2 < _len$5) {
-          const clause = _arr$5[_i$2];
-          const rhs = moonbitlang$core$array$$Array$map$140$(clause.items, (item) => {
-            const _bind$3 = item.symbol;
-            if (_bind$3.$tag === 0) {
-              const _Symbol = _bind$3;
-              const _x$2 = _Symbol._0;
-              return moonbitlang$yacc$lib$driver$$compile$46$get_symbol_by_name$177$(_env$3, _x$2);
+        const _i$2 = _tmp$6;
+        if (_i$2 < _len$6) {
+          const clause = _arr$6[_i$2];
+          const production_num = productions.length;
+          const production = { num: production_num, lhs: lhs, rhs: moonbitlang$core$array$$Array$map$151$(clause.items, (item) => {
+            const _bind$2 = item.desc;
+            if (_bind$2.$tag === 0) {
+              const _Token = _bind$2;
+              const _x$2 = _Token._0;
+              return new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$T(moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$188$(terminal_by_name, _x$2.name));
             } else {
-              const _Image = _bind$3;
-              const _x$2 = _Image._0;
-              return new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$T(moonbitlang$core$option$$Option$unwrap$89$(moonbitlang$core$builtin$$Map$op_get$97$(terminal_by_image, _x$2)));
+              const _RuleCall = _bind$2;
+              const _x$2 = _RuleCall._0;
+              return new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$NT(moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$189$(nonterminal_by_name, _x$2.name));
             }
-          });
-          const num = productions.length;
-          const production = { num: num, lhs: lhs, rhs: rhs, prec: undefined };
-          const _bind$3 = clause.prec;
-          let _tmp$6;
-          if (_bind$3 === undefined) {
-            let last_prec = undefined;
-            const _arr$6 = production.rhs;
-            const _len$6 = _arr$6.length;
-            let _tmp$7 = 0;
-            while (true) {
-              const _i$3 = _tmp$7;
-              if (_i$3 < _len$6) {
-                const symbol = _arr$6[_i$3];
-                if (symbol.$tag === 0) {
-                  const _T = symbol;
-                  const _x$2 = _T._0;
-                  moonbitlang$core$array$$Array$push$131$(_x$2.references, { _0: production, _1: _i$3 });
-                  last_prec = moonbitlang$core$option$$Option$map$52$(_x$2.prec, (_param1) => {
-                    const _x$3 = _param1._0;
-                    return _x$3;
-                  });
-                } else {
-                  const _NT = symbol;
-                  const _x$2 = _NT._0;
-                  moonbitlang$core$array$$Array$push$131$(_x$2.references, { _0: production, _1: _i$3 });
-                }
-                _tmp$7 = _i$3 + 1 | 0;
-                continue;
-              } else {
-                break;
-              }
-            }
-            _tmp$6 = last_prec;
-          } else {
-            const _Some = _bind$3;
-            const _x$2 = _Some;
-            const _bind$4 = moonbitlang$core$option$$Option$unwrap$114$(moonbitlang$core$sorted_map$$T$op_get$58$(prec_map, _x$2));
-            const _x$3 = _bind$4._0;
-            _tmp$6 = _x$3;
-          }
-          production.prec = _tmp$6;
-          moonbitlang$core$array$$Array$push$32$(productions, production);
-          moonbitlang$core$array$$Array$push$32$(lhs.productions, production);
+          }), prec: clause.prec };
+          moonbitlang$core$array$$Array$push$33$(productions, production);
+          moonbitlang$core$array$$Array$push$33$(lhs.productions, production);
           const bindings = [];
-          const visited = moonbitlang$core$sorted_set$$new$19$();
-          const _env$4 = { _0: production, _1: visited, _2: bindings };
+          const visited = moonbitlang$core$sorted_set$$new$22$();
+          const _env = { _0: production, _1: visited, _2: bindings };
           const body = [];
           switch (mode.$tag) {
             case 2: {
@@ -16302,33 +16963,33 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
               break;
             }
             case 0: {
-              const _bind$4 = clause.action.code;
-              if (_bind$4 === undefined) {
-                moonbitlang$core$array$$Array$push$130$(body, { _0: "()", _1: undefined });
+              const _bind$2 = clause.action.code;
+              if (_bind$2 === undefined) {
+                moonbitlang$core$array$$Array$push$138$(body, { _0: "()", _1: undefined });
               } else {
-                const _Some = _bind$4;
+                const _Some = _bind$2;
                 const _x$2 = _Some;
                 const _x$3 = _x$2.code;
                 const _x$4 = _x$2.subst;
                 const _x$5 = _x$2.utf8_pos;
                 let last_index = 0;
-                const _len$6 = _x$4.length;
+                const _len$7 = _x$4.length;
                 let _tmp$7 = 0;
                 while (true) {
                   const _i$3 = _tmp$7;
-                  if (_i$3 < _len$6) {
+                  if (_i$3 < _len$7) {
                     const item = _x$4[_i$3];
                     if (item.start > last_index) {
-                      moonbitlang$core$array$$Array$push$130$(body, { _0: moonbitlang$core$string$$String$substring(_x$3, last_index, item.start), _1: _x$5 + last_index | 0 });
+                      moonbitlang$core$array$$Array$push$138$(body, { _0: moonbitlang$core$string$$String$substring(_x$3, last_index, item.start), _1: _x$5 + last_index | 0 });
                     }
-                    moonbitlang$yacc$lib$driver$$compile$46$add_binding$179$(_env$4, item.desc);
-                    const _bind$5 = item.desc;
+                    moonbitlang$yacc$lib$driver$$compile$46$add_binding$191$(_env, item.desc);
+                    const _bind$3 = item.desc;
                     let _tmp$8;
-                    switch (_bind$5.$tag) {
+                    switch (_bind$3.$tag) {
                       case 0: {
-                        const _Dollar = _bind$5;
+                        const _Dollar = _bind$3;
                         const _x$6 = _Dollar._0;
-                        _tmp$8 = `_dollar${moonbitlang$core$int$$Int$to_string(_x$6)}`;
+                        _tmp$8 = `_dollar${moonbitlang$core$builtin$$Show$to_string$18$(_x$6)}`;
                         break;
                       }
                       case 1: {
@@ -16344,22 +17005,22 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
                         break;
                       }
                       case 4: {
-                        const _StartPosOf = _bind$5;
+                        const _StartPosOf = _bind$3;
                         const _x$7 = _StartPosOf._0;
-                        _tmp$8 = `_start_pos_of_item${moonbitlang$core$int$$Int$to_string(moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$178$(_x$7))}`;
+                        _tmp$8 = `_start_pos_of_item${moonbitlang$core$builtin$$Show$to_string$18$(moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$190$(_x$7))}`;
                         break;
                       }
                       case 5: {
-                        const _EndPosOf = _bind$5;
+                        const _EndPosOf = _bind$3;
                         const _x$8 = _EndPosOf._0;
-                        _tmp$8 = `_end_pos_of_item${moonbitlang$core$int$$Int$to_string(moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$178$(_x$8))}`;
+                        _tmp$8 = `_end_pos_of_item${moonbitlang$core$builtin$$Show$to_string$18$(moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$190$(_x$8))}`;
                         break;
                       }
                       case 6: {
-                        const _LocOf = _bind$5;
+                        const _LocOf = _bind$3;
                         const _x$9 = _LocOf._0;
-                        const index = moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$178$(_x$9);
-                        _tmp$8 = `(_start_pos_of_item${moonbitlang$core$int$$Int$to_string(index)}, _end_pos_of_item${moonbitlang$core$int$$Int$to_string(index)})`;
+                        const index = moonbitlang$yacc$lib$driver$$compile$46$item_ident_to_index$190$(_x$9);
+                        _tmp$8 = `(_start_pos_of_item${moonbitlang$core$builtin$$Show$to_string$18$(index)}, _end_pos_of_item${moonbitlang$core$builtin$$Show$to_string$18$(index)})`;
                         break;
                       }
                       case 7: {
@@ -16370,7 +17031,7 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
                         _tmp$8 = "(_symbol_start_pos, _end_pos)";
                       }
                     }
-                    moonbitlang$core$array$$Array$push$130$(body, { _0: _tmp$8, _1: undefined });
+                    moonbitlang$core$array$$Array$push$138$(body, { _0: _tmp$8, _1: undefined });
                     last_index = item.end;
                     _tmp$7 = _i$3 + 1 | 0;
                     continue;
@@ -16379,15 +17040,15 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
                   }
                 }
                 if (last_index < _x$3.length) {
-                  moonbitlang$core$array$$Array$push$130$(body, { _0: moonbitlang$core$string$$String$substring(_x$3, last_index, _x$3.length), _1: _x$5 + last_index | 0 });
+                  moonbitlang$core$array$$Array$push$138$(body, { _0: moonbitlang$core$string$$String$substring(_x$3, last_index, _x$3.length), _1: _x$5 + last_index | 0 });
                 }
               }
               break;
             }
             default: {
-              moonbitlang$yacc$lib$driver$$compile$46$add_binding$179$(_env$4, $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$StartPos);
-              moonbitlang$yacc$lib$driver$$compile$46$add_binding$179$(_env$4, $64$moonbitlang$47$yacc$47$lib$47$parser$46$SubstItemDesc$EndPos);
-              moonbitlang$core$array$$Array$push$130$(body, { _0: `{\n  \"type\": \"NONTERMINAL\",\n  \"name\": \"${lhs.name}\",\n  \"prod_num\": ${moonbitlang$core$int$$Int$to_string(production.num)},\n  \"children\": args_to_json(_args),\n  \"start\": _start_pos.to_json(),\n  \"end\": _end_pos.to_json(),\n}`, _1: undefined });
+              moonbitlang$yacc$lib$driver$$compile$46$add_binding$191$(_env, $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$StartPos);
+              moonbitlang$yacc$lib$driver$$compile$46$add_binding$191$(_env, $64$moonbitlang$47$yacc$47$lib$47$elab$46$SubstItemDesc$EndPos);
+              moonbitlang$core$array$$Array$push$138$(body, { _0: `{\n  \"type\": \"NONTERMINAL\",\n  \"name\": \"${moonbitlang$core$builtin$$Show$to_string$10$(lhs.name)}\",\n  \"prod_num\": ${moonbitlang$core$builtin$$Show$to_string$18$(production.num)},\n  \"children\": args_to_json(_args),\n  \"start\": _start_pos.to_json(),\n  \"end\": _end_pos.to_json(),\n}`, _1: undefined });
             }
           }
           switch (mode.$tag) {
@@ -16399,19 +17060,19 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
               break;
             }
             default: {
-              const _arr$6 = clause.items;
-              const _len$6 = _arr$6.length;
+              const _arr$7 = clause.items;
+              const _len$7 = _arr$7.length;
               let _tmp$7 = 0;
               while (true) {
                 const _i$3 = _tmp$7;
-                if (_i$3 < _len$6) {
-                  const item = _arr$6[_i$3];
+                if (_i$3 < _len$7) {
+                  const item = _arr$7[_i$3];
                   const _x$2 = item.binder;
                   if (_x$2 === undefined) {
                   } else {
                     const _Some = _x$2;
                     const _x$3 = _Some;
-                    moonbitlang$core$array$$Array$push$129$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$Data(_i$3), _1: _x$3 });
+                    moonbitlang$core$array$$Array$push$137$(bindings, { _0: new $64$moonbitlang$47$yacc$47$lib$47$codegen$46$BindingSubject$Data(_i$3), _1: _x$3 });
                   }
                   _tmp$7 = _i$3 + 1 | 0;
                   continue;
@@ -16421,29 +17082,12 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
               }
             }
           }
-          moonbitlang$core$builtin$$Map$op_set$99$(production_meta_map, num, { bindings: bindings, body: body });
-          _tmp$5 = _i$2 + 1 | 0;
+          moonbitlang$core$builtin$$Map$op_set$102$(production_meta_map, production_num, { bindings: bindings, body: body });
+          _tmp$6 = _i$2 + 1 | 0;
           continue;
         } else {
           break;
         }
-      }
-      _tmp$4 = _i + 1 | 0;
-      continue;
-    } else {
-      break;
-    }
-  }
-  const transient_non_nullables = moonbitlang$core$sorted_set$$from_iter$18$(moonbitlang$core$array$$Array$iter$18$(nonterminals));
-  const _len$5 = nonterminals.length;
-  let _tmp$5 = 0;
-  while (true) {
-    const _i = _tmp$5;
-    if (_i < _len$5) {
-      const nt = nonterminals[_i];
-      if (moonbitlang$core$builtin$$Iter$all$32$(moonbitlang$core$array$$Array$iter$32$(nt.productions), (p) => moonbitlang$core$array$$Array$is_empty$61$(p.rhs))) {
-        nt.nullability = 0;
-        moonbitlang$core$sorted_set$$T$remove$18$(transient_non_nullables, nt);
       }
       _tmp$5 = _i + 1 | 0;
       continue;
@@ -16451,29 +17095,15 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
       break;
     }
   }
-  while (true) {
-    const changed = { val: false };
-    const _bind$2 = moonbitlang$core$sorted_set$$T$iter$18$(transient_non_nullables);
-    _bind$2((nt) => {
-      if (moonbitlang$core$builtin$$Iter$any$32$(moonbitlang$core$array$$Array$iter$32$(nt.productions), (p) => moonbitlang$core$builtin$$Iter$all$61$(moonbitlang$core$array$$Array$iter$61$(p.rhs), moonbitlang$yacc$lib$driver$$compile$46$is_nullable$180$))) {
-        nt.nullability = 1;
-        moonbitlang$core$sorted_set$$T$remove$18$(transient_non_nullables, nt);
-        changed.val = true;
-      }
-      return 1;
-    });
-    if (!changed.val) {
-      break;
-    }
-    continue;
-  }
-  const starts$2 = moonbitlang$core$array$$Array$map$139$(starts, (name) => {
-    const start_nt = moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$176$(_env$2, name);
-    const augmented_start_nt = moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$176$(_env$2, `${name}_prime`);
-    moonbitlang$core$builtin$$Map$op_set$101$(nonterminal_meta_map, augmented_start_nt.num, moonbitlang$core$option$$Option$unwrap$113$(moonbitlang$core$builtin$$Map$op_get$101$(nonterminal_meta_map, start_nt.num)));
+  const starts$2 = moonbitlang$core$array$$Array$map$150$(starts, (name) => {
+    const start_nt = moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$189$(nonterminal_by_name, name);
+    const augmented_start_nt = { num: nonterminals.length, name: `${moonbitlang$core$builtin$$Show$to_string$10$(name)}_prime`, productions: [] };
+    moonbitlang$core$builtin$$Map$op_set$101$(nonterminal_by_name, augmented_start_nt.name, augmented_start_nt);
+    moonbitlang$core$array$$Array$push$96$(nonterminals, augmented_start_nt);
+    moonbitlang$core$builtin$$Map$op_set$104$(nonterminal_meta_map, augmented_start_nt.num, moonbitlang$core$option$$Option$unwrap$121$(moonbitlang$core$builtin$$Map$op_get$104$(nonterminal_meta_map, start_nt.num)));
     const production = { num: productions.length, lhs: augmented_start_nt, rhs: [new $64$moonbitlang$47$yacc$47$lib$47$grm$46$Symbol$NT(start_nt)], prec: undefined };
-    moonbitlang$core$array$$Array$push$131$(start_nt.references, { _0: production, _1: 0 });
-    moonbitlang$core$array$$Array$push$32$(productions, production);
+    moonbitlang$core$array$$Array$push$33$(productions, production);
+    moonbitlang$core$array$$Array$push$33$(augmented_start_nt.productions, production);
     return production;
   });
   const grammar = { starts: starts$2, terminals: terminals, nonterminals: nonterminals, productions: productions };
@@ -16511,7 +17141,7 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
       break;
     }
     case 0: {
-      _tmp$7 = moonbitlang$core$option$$Option$or_default$10$(spec.header);
+      _tmp$7 = moonbitlang$core$option$$Option$or_default$10$(spec$2.header);
       break;
     }
     default: {
@@ -16526,7 +17156,7 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
       break;
     }
     case 0: {
-      _tmp$9 = moonbitlang$core$option$$Option$or_default$10$(spec.trailer);
+      _tmp$9 = moonbitlang$core$option$$Option$or_default$10$(spec$2.trailer);
       break;
     }
     default: {
@@ -16534,7 +17164,7 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
     }
   }
   const meta = { header: _tmp$8, footer: _tmp$9, position_data_type: position_data_type, terminal_meta: (name) => {
-    const meta$2 = moonbitlang$core$builtin$$Map$get_or_init$100$(terminal_meta_map, moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$175$(_env, name).num, () => ({ data_type: undefined, image: undefined }));
+    const meta$2 = moonbitlang$core$builtin$$Map$get_or_init$103$(terminal_meta_map, moonbitlang$yacc$lib$driver$$compile$46$get_terminal_by_name$188$(terminal_by_name, name).num, () => ({ data_type: undefined, image: undefined }));
     _L$2: {
       switch (mode.$tag) {
         case 2: {
@@ -16554,8 +17184,8 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
             if (_x$3 === 0) {
               return { data_type: undefined, image: meta$2.image };
             } else {
-              const _bind$2 = meta$2.data_type;
-              const _tmp$10 = _bind$2 === undefined ? undefined : "Json";
+              const _bind = meta$2.data_type;
+              const _tmp$10 = _bind === undefined ? undefined : "Json";
               return { data_type: _tmp$10, image: meta$2.image };
             }
           }
@@ -16569,13 +17199,13 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
         return $panic();
       }
       case 0: {
-        return moonbitlang$core$option$$Option$unwrap$113$(moonbitlang$core$builtin$$Map$op_get$101$(nonterminal_meta_map, moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$176$(_env$2, name).num));
+        return moonbitlang$core$option$$Option$unwrap$121$(moonbitlang$core$builtin$$Map$op_get$104$(nonterminal_meta_map, moonbitlang$yacc$lib$driver$$compile$46$get_nonterminal_by_name$189$(nonterminal_by_name, name).num));
       }
       default: {
         return { data_type: "Json" };
       }
     }
-  }, production_meta: (num) => moonbitlang$core$option$$Option$unwrap$112$(moonbitlang$core$builtin$$Map$op_get$99$(production_meta_map, num)), derive_map: derive_map };
+  }, production_meta: (num) => moonbitlang$core$option$$Option$unwrap$120$(moonbitlang$core$builtin$$Map$op_get$102$(production_meta_map, num)), derive_map: derive_map };
   const output_buffer = moonbitlang$core$builtin$$StringBuilder$new(moonbitlang$core$builtin$$StringBuilder$new$46$size_hint$46$default());
   const output = moonbitlang$yacc$lib$util$logger_with_cursor$$new({ self: output_buffer, method_0: moonbitlang$core$builtin$$StringBuilder$write_string, method_1: moonbitlang$core$builtin$$StringBuilder$write_substring, method_2: moonbitlang$core$builtin$$Logger$write_sub_string$84$, method_3: moonbitlang$core$builtin$$StringBuilder$write_char }, moonbitlang$yacc$lib$util$logger_with_cursor$$new$46$cursor$46$default());
   const _tmp$10 = moonbitlang$yacc$lib$driver$util$$path_basename(filename);
@@ -16615,15 +17245,18 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
   moonbitlang$yacc$lib$codegen$gen_mbt$$codegen(grammar, automaton, meta, output, source_map_builder, _tmp$10, external_tokens, no_comments, _tmp$12, _tmp$13);
   return moonbitlang$core$builtin$$StringBuilder$to_string(output_buffer);
 }
+function moonbitlang$yacc$main$$_init$42$46$write_map_file$192$(source_map, file) {
+  return moonbitlang$x$fs$$write_string_to_file(file, moonbitlang$core$json$$Json$stringify(moonbitlang$core$builtin$$ToJson$to_json$174$(source_map), moonbitlang$core$json$$Json$stringify$46$escape_slash$46$default(), 2), moonbitlang$x$fs$$write_string_to_file$46$encoding$46$default());
+}
 (() => {
   const output_file = moonbitlang$core$ref$$new$10$("");
-  const output_map_file = moonbitlang$core$ref$$new$30$(undefined);
+  const output_map_file = moonbitlang$core$ref$$new$31$(undefined);
   const input_file = moonbitlang$core$ref$$new$10$("");
-  const mode = moonbitlang$core$ref$$new$29$($64$moonbitlang$47$yacc$47$lib$47$driver$46$Mode$Default);
-  const input_mode = moonbitlang$core$ref$$new$28$(0);
-  const external_tokens = moonbitlang$core$ref$$new$27$(false);
-  const no_comments = moonbitlang$core$ref$$new$27$(false);
-  const token_payload_rewrite = moonbitlang$core$ref$$new$26$(undefined);
+  const mode = moonbitlang$core$ref$$new$30$($64$moonbitlang$47$yacc$47$lib$47$driver$46$Mode$Default);
+  const input_mode = moonbitlang$core$ref$$new$29$(0);
+  const external_tokens = moonbitlang$core$ref$$new$28$(false);
+  const no_comments = moonbitlang$core$ref$$new$28$(false);
+  const token_payload_rewrite = moonbitlang$core$ref$$new$27$(undefined);
   Yoorkin$ArgParser$$parse([{ _0: "--output-file", _1: "-o", _2: new $64$Yoorkin$47$ArgParser$46$Spec$Set_string(output_file), _3: "Output file" }, { _0: "--output-map-file", _1: "--output-map-file", _2: new $64$Yoorkin$47$ArgParser$46$Spec$String((file) => {
     output_map_file.val = file;
   }), _3: "Output source map file, if not specified, it will be the output file with .map.json extension" }, { _0: "--mode", _1: "--mode", _2: new $64$Yoorkin$47$ArgParser$46$Spec$String((mode_sym) => {
@@ -16642,8 +17275,8 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
         break;
       }
       default: {
-        moonbitlang$yacc$lib$driver$util$$println_to_stderr(`Unsupported mode: ${mode_sym}`);
-        _tmp = moonbitlang$yacc$lib$driver$util$$exit$29$(1);
+        moonbitlang$yacc$lib$driver$util$$println_to_stderr(`Unsupported mode: ${moonbitlang$core$builtin$$Show$to_string$10$(mode_sym)}`);
+        _tmp = moonbitlang$yacc$lib$driver$util$$exit$30$(1);
       }
     }
     mode.val = _tmp;
@@ -16658,7 +17291,7 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
         return;
       }
       default: {
-        moonbitlang$yacc$lib$driver$util$$println_to_stderr(`Unsupported input mode: ${input_mode_sym}`);
+        moonbitlang$yacc$lib$driver$util$$println_to_stderr(`Unsupported input mode: ${moonbitlang$core$builtin$$Show$to_string$10$(input_mode_sym)}`);
         moonbitlang$yacc$lib$driver$util$$exit$8$(1);
         return;
       }
@@ -16682,7 +17315,7 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
     let _try_err;
     _L: {
       _L$2: {
-        const _bind = moonbitlang$x$fs$$read_file_to_string(input_file.val);
+        const _bind = moonbitlang$x$fs$$read_file_to_string(input_file.val, moonbitlang$x$fs$$read_file_to_string$46$encoding$46$default());
         if (_bind.$tag === 1) {
           const _ok = _bind;
           parser_spec_src = _ok._0;
@@ -16694,7 +17327,7 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
         }
         break _L;
       }
-      parser_spec_src = moonbitlang$core$builtin$$abort$10$(moonbitlang$core$builtin$$Show$to_string$152$(_try_err));
+      parser_spec_src = moonbitlang$core$builtin$$abort$10$(moonbitlang$core$builtin$$Show$to_string$164$(_try_err));
     }
     const _bind = mode.val;
     let mode$2;
@@ -16704,29 +17337,23 @@ function moonbitlang$yacc$lib$driver$$compile(parser_spec_str, mode, input_mode,
       mode$2 = _bind;
     }
     const source_map = moonbitlang$yacc$lib$codegen$$SourceMap$new();
-    const output = moonbitlang$yacc$lib$driver$$compile(parser_spec_src, mode$2, input_mode.val, input_file.val, external_tokens.val, no_comments.val, { self: source_map, method_0: moonbitlang$yacc$lib$codegen$$SourceMapBuilder$add_mapping$163$ });
-    let file;
-    _L$2: {
-      if (output_file.val === "") {
-        moonbitlang$core$builtin$$println$10$(output);
-        const _bind$2 = output_map_file.val;
-        if (_bind$2 === undefined) {
-          return;
-        } else {
-          const _Some = _bind$2;
-          const _x = _Some;
-          file = _x;
-          break _L$2;
-        }
+    const output = moonbitlang$yacc$lib$driver$$compile(parser_spec_src, mode$2, input_mode.val, input_file.val, external_tokens.val, no_comments.val, { self: source_map, method_0: moonbitlang$yacc$lib$codegen$$SourceMapBuilder$add_mapping$174$ });
+    if (output_file.val === "") {
+      moonbitlang$core$builtin$$println$10$(output);
+      const _bind$2 = output_map_file.val;
+      if (_bind$2 === undefined) {
+        return;
       } else {
-        moonbitlang$x$fs$$write_string_to_file(output_file.val, output);
-        const _tmp = moonbitlang$core$option$$Option$or$10$(output_map_file.val, `${output_file.val}.map.json`);
-        file = _tmp;
-        break _L$2;
+        const _Some = _bind$2;
+        const _x = _Some;
+        moonbitlang$core$result$$Result$unwrap$21$(moonbitlang$yacc$main$$_init$42$46$write_map_file$192$(source_map, _x));
+        return;
       }
+    } else {
+      moonbitlang$core$result$$Result$unwrap$21$(moonbitlang$x$fs$$write_string_to_file(output_file.val, output, moonbitlang$x$fs$$write_string_to_file$46$encoding$46$default()));
+      moonbitlang$core$result$$Result$unwrap$21$(moonbitlang$yacc$main$$_init$42$46$write_map_file$192$(source_map, moonbitlang$core$option$$Option$or$10$(output_map_file.val, `${moonbitlang$core$builtin$$Show$to_string$10$(output_file.val)}.map.json`)));
+      return;
     }
-    moonbitlang$x$fs$$write_string_to_file(file, moonbitlang$core$json$$Json$stringify(moonbitlang$core$builtin$$ToJson$to_json$163$(source_map), moonbitlang$core$json$$Json$stringify$46$escape_slash$46$default(), 2));
-    return;
   } else {
     moonbitlang$yacc$lib$driver$util$$println_to_stderr("Input file is required");
     moonbitlang$yacc$lib$driver$util$$exit$8$(1);

--- a/src/lib/driver/driver.mbt
+++ b/src/lib/driver/driver.mbt
@@ -62,52 +62,41 @@ pub fn compile(
   let terminals = []
   let nonterminals = []
   let terminal_by_name : Map[String, @grm.Terminal] = {}
-  let terminal_by_image : Map[String, @grm.Terminal] = {}
   let nonterminal_by_name : Map[String, @grm.Nonterminal] = {}
-  let production_meta_map : Map[Int, @codegen.ProductionMeta] = {}
-  let terminal_meta_map : Map[Int, @codegen.TerminalMeta] = {}
-  let nonterminal_meta_map : Map[Int, @codegen.NonTerminalMeta] = {}
-  fn get_terminal_by_name(name : String) -> @grm.Terminal {
-    match terminal_by_name.get(name) {
-      Some(t) => t
-      None => {
-        let num = terminals.length()
-        let term : @grm.Terminal = { name, num, prec: None }
-        terminals.push(term)
-        terminal_by_name[name] = term
-        term
-      }
+  for token in spec.tokens {
+    let terminal : @grm.Terminal = {
+      name: token.name,
+      num: token.num,
+      prec: match token.prec {
+        None => None
+        Some((prec, NonAssoc)) => Some((prec, @grm.NonAssoc))
+        Some((prec, LeftAssoc)) => Some((prec, @grm.LeftAssoc))
+        Some((prec, RightAssoc)) => Some((prec, @grm.RightAssoc))
+      },
     }
+    terminal_by_name[token.name] = terminal
+    terminals.push(terminal)
+  }
+  for rule in spec.rules {
+    let nonterminal : @grm.Nonterminal = {
+      name: rule.name,
+      num: rule.num,
+      productions: [],
+    }
+    nonterminal_by_name[rule.name] = nonterminal
+    nonterminals.push(nonterminal)
+  }
+  fn get_terminal_by_name(name : String) -> @grm.Terminal {
+    terminal_by_name.get(name).unwrap()
   }
 
   fn get_nonterminal_by_name(name : String) -> @grm.Nonterminal {
-    match nonterminal_by_name.get(name) {
-      Some(nt) => nt
-      None => {
-        let num = nonterminals.length()
-        let nonterm : @grm.Nonterminal = { name, num, productions: [] }
-        nonterminals.push(nonterm)
-        nonterminal_by_name[name] = nonterm
-        nonterm
-      }
-    }
+    nonterminal_by_name.get(name).unwrap()
   }
 
-  for cmd in spec.decls {
-    match cmd {
-      Token(names, type_~, ..) =>
-        for name in names {
-          let t = get_terminal_by_name(name)
-          terminal_meta_map[t.num] = { data_type: type_, image: None }
-        }
-      Token1(name, type_~, image~) => {
-        let t = get_terminal_by_name(name)
-        terminal_meta_map[t.num] = { data_type: type_, image: Some(image) }
-        terminal_by_image[image] = t
-      }
-      _ => ()
-    }
-  }
+  let production_meta_map : Map[Int, @codegen.ProductionMeta] = {}
+  let terminal_meta_map : Map[Int, @codegen.TerminalMeta] = {}
+  let nonterminal_meta_map : Map[Int, @codegen.NonTerminalMeta] = {}
   match mode {
     OnlyTokens => {
       let output = StringBuilder::new()
@@ -125,9 +114,6 @@ pub fn compile(
     }
     _ => ()
   }
-  for rule in spec.rules {
-    get_nonterminal_by_name(rule.nonterminal) |> ignore
-  }
   fn get_symbol_by_name(name : String) -> @grm.Symbol {
     match terminal_by_name.get(name) {
       Some(t) => T(t)
@@ -137,12 +123,10 @@ pub fn compile(
 
   let productions = []
   let starts : Array[String] = []
-  let mut curr_prec = 0
   let mut position_data_type = "Unit"
   let mut derive_map = @immut/hashmap.new()
-  let prec_map = @sorted_map.new()
-  for cmd in spec.decls {
-    match cmd {
+  for decl in spec.decls {
+    match decl {
       Token(_) | Token1(_) => ()
       Start(names) => starts.push_iter(names.iter())
       Type(names, type_~) =>
@@ -154,19 +138,7 @@ pub fn compile(
           }
         }
       Position(type_~) => position_data_type = type_
-      Left(names) | Right(names) | Nonassoc(names) => {
-        let assoc : @grm.Associativity = match cmd {
-          Left(_) => LeftAssoc
-          Right(_) => RightAssoc
-          Nonassoc(_) => NonAssoc
-          _ => panic()
-        }
-        let prec = curr_prec
-        curr_prec += 1
-        for name in names {
-          prec_map[name] = (prec, assoc)
-        }
-      }
+      Left(_) | Right(_) | Nonassoc(_) => ()
       Derive(traits~, type_~) => {
         let type_ : @codegen.PubType = match type_ {
           "Token" => Token
@@ -197,14 +169,15 @@ pub fn compile(
       }
     }
   }
-  for name, prec in prec_map {
-    match terminal_by_name.get(name) {
-      Some(t) => t.prec = Some(prec)
-      None => ()
+  for token in spec.tokens {
+    let terminal = get_terminal_by_name(token.name)
+    terminal_meta_map[terminal.num] = {
+      data_type: token.type_,
+      image: token.image,
     }
   }
   for rule in spec.rules {
-    let lhs = get_nonterminal_by_name(rule.nonterminal)
+    let lhs = get_nonterminal_by_name(rule.name)
     match rule.type_ {
       Some(type_) => nonterminal_meta_map[lhs.num] = { data_type: type_ }
       None =>
@@ -214,31 +187,17 @@ pub fn compile(
         }
     }
     for clause in rule.clauses {
-      let rhs = clause.items.map(fn(item) {
-        match item.symbol {
-          Symbol(symbol) => get_symbol_by_name(symbol)
-          Image(image) => T(terminal_by_image[image].unwrap())
-        }
-      })
-      let num = productions.length()
-      let production : @grm.Production = { num, lhs, rhs, prec: None }
-      production.prec = match clause.prec {
-        Some(prec) => {
-          // TODO: error reporting
-          let (level, _assoc) = prec_map[prec].unwrap()
-          Some(level)
-        }
-        None => {
-          // TODO: Reconsider this
-          let mut last_prec = None
-          for symbol in production.rhs {
-            match symbol {
-              T(t) => last_prec = t.prec.map(fn { (level, _) => level })
-              NT(_) => ()
-            }
+      let production_num = productions.length()
+      let production : @grm.Production = {
+        num: production_num,
+        lhs,
+        rhs: clause.items.map(fn(item) {
+          match item.desc {
+            Token(token) => T(get_terminal_by_name(token.name))
+            RuleCall(rule) => NT(get_nonterminal_by_name(rule.name))
           }
-          last_prec
-        }
+        }),
+        prec: clause.prec,
       }
       productions.push(production)
       lhs.productions.push(production)
@@ -371,18 +330,23 @@ pub fn compile(
         Default =>
           for index, item in clause.items {
             match item {
-              { symbol: _, binder: Some(name) } =>
-                bindings.push((Data(index), name))
+              { binder: Some(name), .. } => bindings.push((Data(index), name))
               _ => ()
             }
           }
       }
-      production_meta_map[num] = { bindings, body }
+      production_meta_map[production_num] = { bindings, body }
     }
   }
   let starts = starts.map(fn(name) {
     let start_nt = get_nonterminal_by_name(name)
-    let augmented_start_nt = get_nonterminal_by_name("\{name}_prime")
+    let augmented_start_nt : @grm.Nonterminal = {
+      num: nonterminals.length(),
+      name: "\{name}_prime",
+      productions: [],
+    }
+    nonterminal_by_name[augmented_start_nt.name] = augmented_start_nt
+    nonterminals.push(augmented_start_nt)
     nonterminal_meta_map[augmented_start_nt.num] = nonterminal_meta_map[start_nt.num].unwrap()
     let production : @grm.Production = {
       num: productions.length(),
@@ -391,6 +355,7 @@ pub fn compile(
       prec: None,
     }
     productions.push(production)
+    augmented_start_nt.productions.push(production)
     production
   })
   let grammar : @grm.Grammar = { terminals, nonterminals, productions, starts }

--- a/src/lib/driver/driver.mbt
+++ b/src/lib/driver/driver.mbt
@@ -58,6 +58,7 @@ pub fn compile(
       exit(1)
     }
   }
+  let spec = @elab.elaborate(spec)
   let terminals = []
   let nonterminals = []
   let terminal_by_name : Map[String, @grm.Terminal] = {}
@@ -241,7 +242,7 @@ pub fn compile(
       }
       productions.push(production)
       lhs.productions.push(production)
-      fn item_ident_to_index(ident : @parser.ClauseItemIdent) -> Int {
+      fn item_ident_to_index(ident : @elab.ClauseItemIdent) -> Int {
         match ident {
           Dollar(index) => index
           Name(_) => panic()
@@ -250,7 +251,7 @@ pub fn compile(
 
       let bindings : Array[(@codegen.BindingSubject, @codegen.CodeFragment)] = []
       let visited = @sorted_set.new()
-      fn add_binding(desc : @parser.SubstItemDesc) {
+      fn add_binding(desc : @elab.SubstItemDesc) {
         guard not(visited.contains(desc)) else { return }
         visited.add(desc)
         match desc {

--- a/src/lib/driver/moon.pkg.json
+++ b/src/lib/driver/moon.pkg.json
@@ -13,6 +13,7 @@
       ]
     },
     "moonbitlang/yacc/lib/codegen/gen_mbt",
-    "moonbitlang/yacc/lib/util/logger_with_cursor"
+    "moonbitlang/yacc/lib/util/logger_with_cursor",
+    "moonbitlang/yacc/lib/elab"
   ]
 }

--- a/src/lib/elab/east.mbt
+++ b/src/lib/elab/east.mbt
@@ -13,11 +13,28 @@
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ///|
+pub(all) enum Associativity {
+  LeftAssoc
+  RightAssoc
+  NonAssoc
+} derive(ToJson)
+
+///|
 pub(all) struct ParserSpec {
   header : Code?
   trailer : Code?
   decls : Array[Declaration]
+  tokens : Array[Token]
   rules : Array[Rule]
+} derive(ToJson)
+
+///|
+pub(all) struct Token {
+  num : Int
+  name : String
+  mut prec : (Int, Associativity)?
+  mut type_ : Code?
+  mut image : String?
 } derive(ToJson)
 
 ///|
@@ -67,7 +84,8 @@ pub(all) enum Declaration {
 
 ///|
 pub(all) struct Rule {
-  nonterminal : Symbol
+  num : Int
+  name : Symbol
   type_ : Code?
   clauses : Array[Clause]
 } derive(ToJson)
@@ -75,7 +93,7 @@ pub(all) struct Rule {
 ///|
 pub(all) struct Clause {
   items : Array[ClauseItem]
-  prec : Symbol?
+  prec : Int?
   action : ClauseAction
 } derive(ToJson)
 
@@ -96,11 +114,11 @@ pub(all) struct CodeWithSubst {
 ///|
 pub(all) struct ClauseItem {
   binder : Code?
-  symbol : ClauseItemSymbol
+  desc : ClauseItemDesc
 } derive(ToJson)
 
 ///|
-pub(all) enum ClauseItemSymbol {
-  Symbol(Symbol)
-  Image(String)
+pub(all) enum ClauseItemDesc {
+  Token(Token)
+  RuleCall(Rule)
 } derive(ToJson)

--- a/src/lib/elab/east.mbt
+++ b/src/lib/elab/east.mbt
@@ -1,0 +1,106 @@
+// Copyright (C) 2025 International Digital Economy Academy
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+///|
+pub(all) struct ParserSpec {
+  header : Code?
+  trailer : Code?
+  decls : Array[Declaration]
+  rules : Array[Rule]
+} derive(ToJson)
+
+///|
+pub(all) typealias Code = String
+
+///|
+pub(all) enum SubstItemDesc {
+  Dollar(Int)
+  StartPos
+  EndPos
+  Loc
+  StartPosOf(ClauseItemIdent)
+  EndPosOf(ClauseItemIdent)
+  LocOf(ClauseItemIdent)
+  SymbolStartPos
+  Sloc
+} derive(Eq, Compare, Show, ToJson)
+
+///|
+pub(all) enum ClauseItemIdent {
+  Dollar(Int)
+  Name(Code)
+} derive(Eq, Compare, Show, ToJson)
+
+///|
+pub(all) struct SubstItem {
+  start : Int
+  end : Int
+  desc : SubstItemDesc
+} derive(Show, ToJson)
+
+///|
+pub(all) typealias Symbol = String
+
+///|
+pub(all) enum Declaration {
+  Start(Array[Symbol])
+  Token(Array[Symbol], type_~ : Code?)
+  Token1(Symbol, type_~ : Code?, image~ : String)
+  Type(Array[Symbol], type_~ : Code)
+  Derive(traits~ : Code, type_~ : Code)
+  Position(type_~ : Code)
+  Left(Array[Symbol])
+  Right(Array[Symbol])
+  Nonassoc(Array[Symbol])
+} derive(ToJson)
+
+///|
+pub(all) struct Rule {
+  nonterminal : Symbol
+  type_ : Code?
+  clauses : Array[Clause]
+} derive(ToJson)
+
+///|
+pub(all) struct Clause {
+  items : Array[ClauseItem]
+  prec : Symbol?
+  action : ClauseAction
+} derive(ToJson)
+
+///|
+pub(all) struct ClauseAction {
+  code : CodeWithSubst?
+  start : Int
+  end : Int
+} derive(ToJson)
+
+///|
+pub(all) struct CodeWithSubst {
+  code : Code
+  utf8_pos : Int
+  subst : Array[SubstItem]
+} derive(ToJson)
+
+///|
+pub(all) struct ClauseItem {
+  binder : Code?
+  symbol : ClauseItemSymbol
+} derive(ToJson)
+
+///|
+pub(all) enum ClauseItemSymbol {
+  Symbol(Symbol)
+  Image(String)
+} derive(ToJson)

--- a/src/lib/elab/elaborate.mbt
+++ b/src/lib/elab/elaborate.mbt
@@ -2,74 +2,190 @@
 pub fn elaborate(ast_spec : @parser.ParserSpec) -> ParserSpec {
   let header = ast_spec.header
   let trailer = ast_spec.trailer
-  let decls = ast_spec.decls.map(fn(ast_decl) {
-    match ast_decl {
-      Start(symbols) => Start(symbols)
-      Token(symbols, type_~) => Token(symbols, type_~)
-      Token1(symbols, type_~, image~) => Token1(symbols, type_~, image~)
-      Type(symbols, type_~) => Type(symbols, type_~)
-      Derive(traits~, type_~) => Derive(traits~, type_~)
-      Position(type_~) => Position(type_~)
-      Left(symbols) => Left(symbols)
-      Right(symbols) => Right(symbols)
-      Nonassoc(symbols) => Nonassoc(symbols)
-    }
-  })
-  fn map_item_ident(
-    ast_item_ident : @parser.ClauseItemIdent
-  ) -> ClauseItemIdent {
-    match ast_item_ident {
-      Dollar(x) => Dollar(x)
-      Name(name) => Name(name)
+  let token_by_name : Map[String, Token] = {}
+  let rule_by_name : Map[String, Rule] = {}
+  let token_by_image : Map[String, Token] = {}
+  let tokens : Array[Token] = []
+  let rules : Array[Rule] = []
+  fn get_token_by_name(name : String) -> Token {
+    match token_by_name.get(name) {
+      Some(t) => t
+      None => {
+        let token : Token = {
+          num: token_by_name.size(),
+          name,
+          type_: None,
+          image: None,
+          prec: None,
+        }
+        token_by_name[name] = token
+        tokens.push(token)
+        token
+      }
     }
   }
 
-  let rules = ast_spec.rules.map(fn(ast_rule) {
-    let clauses = ast_rule.clauses.map(fn(ast_clause) {
+  // Prepare tokens
+  for ast_decl in ast_spec.decls {
+    match ast_decl {
+      Token(names, type_~, ..) =>
+        for name in names {
+          let token = get_token_by_name(name)
+          token.type_ = type_
+        }
+      Token1(name, type_~, image~) => {
+        let token = get_token_by_name(name)
+        token.type_ = type_
+        token.image = Some(image)
+        token_by_image[image] = token
+      }
+      _ => ()
+    }
+  }
+
+  // Prepare rules
+  for ast_rule in ast_spec.rules {
+    let rule : Rule = {
+      num: rule_by_name.size(),
+      name: ast_rule.nonterminal,
+      type_: ast_rule.type_,
+      clauses: [],
+    }
+    rules.push(rule)
+    rule_by_name[rule.name] = rule
+  }
+  let mut curr_prec = 0
+  let prec_map = @sorted_map.new()
+  for ast_decl in ast_spec.decls {
+    match ast_decl {
+      Left(idents) | Right(idents) | Nonassoc(idents) => {
+        let assoc : Associativity = match ast_decl {
+          Left(_) => LeftAssoc
+          Right(_) => RightAssoc
+          Nonassoc(_) => NonAssoc
+          _ => panic()
+        }
+        let prec = curr_prec
+        curr_prec += 1
+        for ident in idents {
+          prec_map[ident] = (prec, assoc)
+          match token_by_name[ident] {
+            None => ()
+            Some(token) => token.prec = Some((prec, assoc))
+          }
+        }
+      }
+      _ => ()
+    }
+  }
+  let decls = ast_spec.decls.map(map_decl)
+  for ast_rule in ast_spec.rules {
+    let rule = rule_by_name[ast_rule.nonterminal].unwrap()
+    for ast_clause in ast_rule.clauses {
       let items = ast_clause.items.map(fn(ast_item) {
         ClauseItem::{
           binder: ast_item.binder,
-          symbol: match ast_item.symbol {
-            Symbol(symbol) => Symbol(symbol)
-            Image(symbol) => Image(symbol)
+          desc: match ast_item.symbol {
+            Symbol(symbol) =>
+              match token_by_name[symbol] {
+                None => RuleCall(rule_by_name[symbol].unwrap())
+                Some(token) => Token(token)
+              }
+            Image(image) => Token(token_by_image[image].unwrap())
           },
         }
       })
-      Clause::{
-        items,
-        prec: ast_clause.prec,
-        action: ClauseAction::{
-          code: match ast_clause.action.code {
-            None => None
-            Some(code) =>
-              Some(CodeWithSubst::{
-                code: code.code,
-                utf8_pos: code.utf8_pos,
-                subst: code.subst.map(fn(ast_subst) {
-                  SubstItem::{
-                    start: ast_subst.start,
-                    end: ast_subst.end,
-                    desc: match ast_subst.desc {
-                      Dollar(x) => Dollar(x)
-                      StartPos => StartPos
-                      EndPos => EndPos
-                      Loc => Loc
-                      StartPosOf(x) => StartPosOf(map_item_ident(x))
-                      EndPosOf(x) => EndPosOf(map_item_ident(x))
-                      LocOf(x) => LocOf(map_item_ident(x))
-                      SymbolStartPos => SymbolStartPos
-                      Sloc => Sloc
-                    },
-                  }
-                }),
-              })
-          },
-          start: ast_clause.action.start,
-          end: ast_clause.action.end,
-        },
+      let prec = match ast_clause.prec {
+        Some(prec) => {
+          // TODO: error reporting
+          let (prec, _assoc) = prec_map[prec].unwrap()
+          Some(prec)
+        }
+        None => {
+          /// FROM ocamlyacc's manual
+          // > Tokens and rules have precedences.
+          // > By default, the precedence of a rule is the precedence of its rightmost terminal.
+          // I don't what "rightmost terminal" means, but I guess it means the last terminal in the rule.
+          // So, I'll use the precedence of the last terminal in the rule.
+          let mut last_prec = None
+          for item in items.rev_iter() {
+            match item.desc {
+              Token(token) => {
+                last_prec = match token.prec {
+                  None => None
+                  Some((prec, _assoc)) => Some(prec)
+                }
+                break
+              }
+              RuleCall(_) => ()
+            }
+          }
+          last_prec
+        }
       }
-    })
-    Rule::{ nonterminal: ast_rule.nonterminal, type_: ast_rule.type_, clauses }
-  })
-  ParserSpec::{ header, decls, trailer, rules }
+      let clause = Clause::{
+        items,
+        prec,
+        action: map_action(ast_clause.action),
+      }
+      rule.clauses.push(clause)
+    }
+  }
+  ParserSpec::{ header, decls, trailer, tokens, rules }
+}
+
+///|
+fn map_decl(ast_decl : @parser.Declaration) -> Declaration {
+  match ast_decl {
+    Start(symbols) => Start(symbols)
+    Token(symbols, type_~) => Token(symbols, type_~)
+    Token1(symbols, type_~, image~) => Token1(symbols, type_~, image~)
+    Type(symbols, type_~) => Type(symbols, type_~)
+    Derive(traits~, type_~) => Derive(traits~, type_~)
+    Position(type_~) => Position(type_~)
+    Left(symbols) => Left(symbols)
+    Right(symbols) => Right(symbols)
+    Nonassoc(symbols) => Nonassoc(symbols)
+  }
+}
+
+///|
+fn map_action(ast_action : @parser.ClauseAction) -> ClauseAction {
+  ClauseAction::{
+    code: match ast_action.code {
+      None => None
+      Some(code) =>
+        Some(CodeWithSubst::{
+          code: code.code,
+          utf8_pos: code.utf8_pos,
+          subst: code.subst.map(fn(ast_subst) {
+            SubstItem::{
+              start: ast_subst.start,
+              end: ast_subst.end,
+              desc: match ast_subst.desc {
+                Dollar(x) => Dollar(x)
+                StartPos => StartPos
+                EndPos => EndPos
+                Loc => Loc
+                StartPosOf(x) => StartPosOf(map_item_ident(x))
+                EndPosOf(x) => EndPosOf(map_item_ident(x))
+                LocOf(x) => LocOf(map_item_ident(x))
+                SymbolStartPos => SymbolStartPos
+                Sloc => Sloc
+              },
+            }
+          }),
+        })
+    },
+    start: ast_action.start,
+    end: ast_action.end,
+  }
+}
+
+///|
+fn map_item_ident(ast_item_ident : @parser.ClauseItemIdent) -> ClauseItemIdent {
+  match ast_item_ident {
+    Dollar(x) => Dollar(x)
+    Name(name) => Name(name)
+  }
 }

--- a/src/lib/elab/elaborate.mbt
+++ b/src/lib/elab/elaborate.mbt
@@ -1,0 +1,75 @@
+///|
+pub fn elaborate(ast_spec : @parser.ParserSpec) -> ParserSpec {
+  let header = ast_spec.header
+  let trailer = ast_spec.trailer
+  let decls = ast_spec.decls.map(fn(ast_decl) {
+    match ast_decl {
+      Start(symbols) => Start(symbols)
+      Token(symbols, type_~) => Token(symbols, type_~)
+      Token1(symbols, type_~, image~) => Token1(symbols, type_~, image~)
+      Type(symbols, type_~) => Type(symbols, type_~)
+      Derive(traits~, type_~) => Derive(traits~, type_~)
+      Position(type_~) => Position(type_~)
+      Left(symbols) => Left(symbols)
+      Right(symbols) => Right(symbols)
+      Nonassoc(symbols) => Nonassoc(symbols)
+    }
+  })
+  fn map_item_ident(
+    ast_item_ident : @parser.ClauseItemIdent
+  ) -> ClauseItemIdent {
+    match ast_item_ident {
+      Dollar(x) => Dollar(x)
+      Name(name) => Name(name)
+    }
+  }
+
+  let rules = ast_spec.rules.map(fn(ast_rule) {
+    let clauses = ast_rule.clauses.map(fn(ast_clause) {
+      let items = ast_clause.items.map(fn(ast_item) {
+        ClauseItem::{
+          binder: ast_item.binder,
+          symbol: match ast_item.symbol {
+            Symbol(symbol) => Symbol(symbol)
+            Image(symbol) => Image(symbol)
+          },
+        }
+      })
+      Clause::{
+        items,
+        prec: ast_clause.prec,
+        action: ClauseAction::{
+          code: match ast_clause.action.code {
+            None => None
+            Some(code) =>
+              Some(CodeWithSubst::{
+                code: code.code,
+                utf8_pos: code.utf8_pos,
+                subst: code.subst.map(fn(ast_subst) {
+                  SubstItem::{
+                    start: ast_subst.start,
+                    end: ast_subst.end,
+                    desc: match ast_subst.desc {
+                      Dollar(x) => Dollar(x)
+                      StartPos => StartPos
+                      EndPos => EndPos
+                      Loc => Loc
+                      StartPosOf(x) => StartPosOf(map_item_ident(x))
+                      EndPosOf(x) => EndPosOf(map_item_ident(x))
+                      LocOf(x) => LocOf(map_item_ident(x))
+                      SymbolStartPos => SymbolStartPos
+                      Sloc => Sloc
+                    },
+                  }
+                }),
+              })
+          },
+          start: ast_clause.action.start,
+          end: ast_clause.action.end,
+        },
+      }
+    })
+    Rule::{ nonterminal: ast_rule.nonterminal, type_: ast_rule.type_, clauses }
+  })
+  ParserSpec::{ header, decls, trailer, rules }
+}

--- a/src/lib/elab/moon.pkg.json
+++ b/src/lib/elab/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "import": [
+    "moonbitlang/yacc/lib/parser"
+  ]
+}


### PR DESCRIPTION
This PR add an elaborate phase, and an IR east.

```
ast -> [ elaborate ] -> east -> grammar -> lr1 automaton -> .mbt
```

Later we can desugar `%inline` rule at elaborate phase.  And report grammar issues at elaborate phase.

## Motivation 

Currently, driver process `ast` to `grammar` then build `lr1 automaton`. It is not suitable to desugar %inline at `ast` or `grammar` level.
