### PR TITLE
fix: handle empty token arrays with an initial position

### DIFF
--- a/codegen/gen_mbt/gen_mbt.mbt
+++ b/codegen/gen_mbt/gen_mbt.mbt
@@ -920,7 +920,7 @@ fn codegen(
           $|  let mut cursor = 0
           $|  let mut state_stack : @list.List[YYState] = @list.cons(start, @list.empty())
           $|  let data_stack : Array[(YYObj, \{meta.position_data_type}, \{meta.position_data_type})] = []
-          $|  let mut last_pos = initial_pos.unwrap_or(tokens[0].1)
+          $|  let mut last_pos = initial_pos.unwrap_or_else(fn() { tokens[0].1 })
           $|  let mut state = start
           $|  let mut lookahead : Option[(YYSymbol, (YYObj, \{meta.position_data_type}, \{meta.position_data_type}), Token?)] = None
           $|  let mut last_shifted_state_stack = state_stack

--- a/codegen/gen_mbt_table/gen_mbt_table.mbt
+++ b/codegen/gen_mbt_table/gen_mbt_table.mbt
@@ -1020,7 +1020,7 @@ fn codegen(
           $|  let mut cursor = 0
           $|  let mut state_stack : @list.List[YYState] = @list.cons(start, @list.empty())
           $|  let data_stack : Array[(YYObj, \{meta.position_data_type}, \{meta.position_data_type})] = []
-          $|  let mut last_pos = initial_pos.unwrap_or(tokens[0].1)
+          $|  let mut last_pos = initial_pos.unwrap_or_else(fn() { tokens[0].1 })
           $|  let mut state = start
           $|  let mut lookahead : Option[(YYSymbol, (YYObj, \{meta.position_data_type}, \{meta.position_data_type}), Token?)] = None
           $|  let mut last_shifted_state_stack = state_stack

--- a/tests/rule_with_params_test/parser.mbt
+++ b/tests/rule_with_params_test/parser.mbt
@@ -213,7 +213,7 @@ fn[T] yy_parse(
   let mut cursor = 0
   let mut state_stack : @list.List[YYState] = @list.cons(start, @list.empty())
   let data_stack : Array[(YYObj, Unit, Unit)] = []
-  let mut last_pos = initial_pos.unwrap_or(tokens[0].1)
+  let mut last_pos = initial_pos.unwrap_or_else(fn() { tokens[0].1 })
   let mut state = start
   let mut lookahead : Option[(YYSymbol, (YYObj, Unit, Unit), Token?)] = None
   let mut last_shifted_state_stack = state_stack

--- a/tests/rule_with_params_test/parser_wbtest.mbt
+++ b/tests/rule_with_params_test/parser_wbtest.mbt
@@ -24,3 +24,8 @@ test {
   let result = start(tokens, initial_pos=())
   assert_eq(result, "abc")
 }
+
+///|
+test "empty input with initial position" {
+  assert_eq(start([], initial_pos=()), "")
+}


### PR DESCRIPTION
Use `unwrap_or_else` in both codegen backends to avoid evaluating `tokens[0]` when `initial_pos` is provided. Add an empty-input regression test and regenerate its parser.